### PR TITLE
Make TagIter use explicit lifetimes

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 #[repr(C)]
 pub struct Tag {
     pub typ: u32,
@@ -5,14 +7,15 @@ pub struct Tag {
     // tag specific fields
 }
 
-pub struct TagIter {
+pub struct TagIter<'a> {
     pub current: *const Tag,
+    pub phantom: PhantomData<&'a Tag>,
 }
 
-impl Iterator for TagIter {
-    type Item = &'static Tag;
+impl<'a> Iterator for TagIter<'a> {
+    type Item = &'a Tag;
 
-    fn next(&mut self) -> Option<&'static Tag> {
+    fn next(&mut self) -> Option<&'a Tag> {
         match unsafe{&*self.current} {
             &Tag{typ:0, size:8} => None, // end tag
             tag => {
@@ -26,4 +29,3 @@ impl Iterator for TagIter {
         }
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 use core::fmt;
+use core::marker::PhantomData;
 
 use header::{Tag, TagIter};
 pub use boot_loader_name::BootLoaderNameTag;
@@ -80,12 +81,12 @@ impl BootInformation {
         end_tag.typ == END_TAG.typ && end_tag.size == END_TAG.size
     }
 
-    fn get_tag(&self, typ: u32) -> Option<&'static Tag> {
+    fn get_tag<'a>(&'a self, typ: u32) -> Option<&'a Tag> {
         self.tags().find(|tag| tag.typ == typ)
     }
 
     fn tags(&self) -> TagIter {
-        TagIter { current: &self.first_tag as *const _ }
+        TagIter { current: &self.first_tag as *const _, phantom: PhantomData }
     }
 }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -36,14 +36,14 @@ pub fn module_iter(iter: TagIter) -> ModuleIter {
     ModuleIter { iter: iter }
 }
 
-pub struct ModuleIter {
-    iter: TagIter,
+pub struct ModuleIter<'a> {
+    iter: TagIter<'a>,
 }
 
-impl Iterator for ModuleIter {
-    type Item = &'static ModuleTag;
+impl<'a> Iterator for ModuleIter<'a> {
+    type Item = &'a ModuleTag;
 
-    fn next(&mut self) -> Option<&'static ModuleTag> {
+    fn next(&mut self) -> Option<&'a ModuleTag> {
         self.iter.find(|x| x.typ == 3)
             .map(|tag| unsafe{&*(tag as *const Tag as *const ModuleTag)})
     }


### PR DESCRIPTION
This is a move away from the many 'static lifetimes, as proposed in issue #22.

Small question regarding the specific implementation:
I made the `phantom` field of `TagIter` public, because a `TagIter` is constructed in `src/lib.rs` and I didn’t want to introduce a `TagIter::new()` method without approval. I don’t know which is better style here: making `phantom` public, as done in this PR, or make a `new()` function.