### PR TITLE
Fix travis badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # multiboot2-elf64
-[![Build Status](https://travis-ci.org/phil-opp/multiboot2-elf64.svg?branch=master)](https://travis-ci.org/phil-opp/multiboot2-elf64)
+[![Build Status](https://travis-ci.org/rust-osdev/multiboot2-elf64.svg?branch=master)](https://travis-ci.org/rust-osdev/multiboot2-elf64)
 
 An experimental Multiboot 2 crate for ELF-64 kernels. It's still incomplete, so please open an issue if you're missing some functionality. Contributions welcome!
 


### PR DESCRIPTION
After moving the repository under `rust-osdev`, we need to update the pointer to the Travis build status