### PR TITLE
Methods to validate RSDP tags and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multiboot2"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Philipp Oppermann <dev@phil-opp.com>", "Calvin Lee <cyrus296@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental Multiboot 2 crate for ELF-64/32 kernels."


### PR DESCRIPTION
This add methods to the RSDP tags to validate them (slightly paranoid but still good practice) and tests for the GRUB2 tags. It also bumps the version to 0.6.0, as I'd like to get this published so I can use it without having to do a patch :)