### PR TITLE
Multiboot2 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multiboot2"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Philipp Oppermann <dev@phil-opp.com>", "Calvin Lee <cyrus296@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental Multiboot 2 crate for ELF-64/32 kernels."


### PR DESCRIPTION
This bumps the version, after which I will publish the new version, as suggested in [#46 (comment)](https://github.com/rust-osdev/multiboot2-elf64/pull/46#issuecomment-397557208)

Could I get a review from someone please @rust-osdev/multiboot2 