### PR TITLE
Return memory_map entries as u64, to support 32-bit targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multiboot2"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Philipp Oppermann <dev@phil-opp.com>", "Calvin Lee <cyrus296@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental Multiboot 2 crate for ELF-64/32 kernels."

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -30,12 +30,12 @@ pub struct MemoryArea {
 }
 
 impl MemoryArea {
-    pub fn start_address(&self) -> usize {
-        self.base_addr as usize
+    pub fn start_address(&self) -> u64 {
+        self.base_addr
     }
 
-    pub fn end_address(&self) -> usize {
-        (self.base_addr + self.length) as usize
+    pub fn end_address(&self) -> u64 {
+        (self.base_addr + self.length)
     }
 
     pub fn size(&self) -> usize {


### PR DESCRIPTION
Fixes #49 

Note: This is a breaking change.