### PR TITLE
Return u64 from MemoryArea::size as well

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multiboot2"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Philipp Oppermann <dev@phil-opp.com>", "Calvin Lee <cyrus296@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental Multiboot 2 crate for ELF-64/32 kernels."

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -38,8 +38,8 @@ impl MemoryArea {
         (self.base_addr + self.length)
     }
 
-    pub fn size(&self) -> usize {
-        self.length as usize
+    pub fn size(&self) -> u64 {
+        self.length
     }
 }
 

--- a/src/rsdp.rs
+++ b/src/rsdp.rs
@@ -37,6 +37,7 @@ impl RsdpV1Tag {
         self.revision
     }
 
+    /// Get the physical address of the RSDT.
     pub fn rsdt_address(&self) -> usize {
         self.rsdt_address as usize
     }
@@ -75,6 +76,7 @@ impl RsdpV2Tag {
         self.revision
     }
 
+    /// Get the physical address of the XSDT. On x86, this is truncated from 64-bit to 32-bit.
     pub fn xsdt_address(&self) -> usize {
         self.xsdt_address as usize
     }


### PR DESCRIPTION
Looks like I was a bit hasty merging #50 and missed that we're still returning a `usize` from the `size` method. I've also bumped the version to `0.7.1` from `0.7.0`, as this only patches the previous breaking change.

@rust-osdev/multiboot2 could I get a review so I can publish the new version (`0.7.0` is already published, it'd be good to minimise the number of people who upgrade and have to work around this)