### PR TITLE
Use no `'static` lifetimes anymore

### DIFF
--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -55,7 +55,7 @@ pub fn framebuffer_tag<'a>(tag: &'a Tag) -> FramebufferTag<'a> {
             let num_colors = reader.read_u32();
             let palette = unsafe {
                 slice::from_raw_parts(reader.read_u32() as usize as *const FramebufferColor, num_colors as usize)
-            } as &'static [FramebufferColor];
+            } as &'a [FramebufferColor];
             FramebufferType::Indexed { palette }
         },
         1 => {

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct Tag {
@@ -7,14 +9,24 @@ pub struct Tag {
 }
 
 #[derive(Clone, Debug)]
-pub struct TagIter {
+pub struct TagIter<'a> {
     pub current: *const Tag,
+    phantom: PhantomData<&'a Tag>,
 }
 
-impl Iterator for TagIter {
-    type Item = &'static Tag;
+impl<'a> TagIter<'a> {
+    pub fn new(first: *const Tag) -> Self {
+        TagIter {
+            current: first,
+            phantom: PhantomData,
+        }
+    }
+}
 
-    fn next(&mut self) -> Option<&'static Tag> {
+impl<'a> Iterator for TagIter<'a> {
+    type Item = &'a Tag;
+
+    fn next(&mut self) -> Option<&'a Tag> {
         match unsafe{&*self.current} {
             &Tag{typ:0, size:8} => None, // end tag
             tag => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ impl BootInformation {
         })
     }
 
-    pub fn memory_map_tag(&self) -> Option<&'static MemoryMapTag> {
+    pub fn memory_map_tag<'a>(&'a self) -> Option<&'a MemoryMapTag> {
         self.get_tag(6).map(|tag| unsafe { &*(tag as *const Tag as *const MemoryMapTag) })
     }
 
@@ -82,23 +82,23 @@ impl BootInformation {
         module::module_iter(self.tags())
     }
 
-    pub fn boot_loader_name_tag(&self) -> Option<&'static BootLoaderNameTag> {
+    pub fn boot_loader_name_tag<'a>(&'a self) -> Option<&'a BootLoaderNameTag> {
         self.get_tag(2).map(|tag| unsafe { &*(tag as *const Tag as *const BootLoaderNameTag) })
     }
 
-    pub fn command_line_tag(&self) -> Option<&'static CommandLineTag> {
+    pub fn command_line_tag<'a>(&'a self) -> Option<&'a CommandLineTag> {
         self.get_tag(1).map(|tag| unsafe { &*(tag as *const Tag as *const CommandLineTag) })
     }
 
-    pub fn framebuffer_tag(&self) -> Option<FramebufferTag<'static>> {
+    pub fn framebuffer_tag<'a>(&'a self) -> Option<FramebufferTag<'a>> {
         self.get_tag(8).map(|tag| framebuffer::framebuffer_tag(tag))
     }
 
-    pub fn rsdp_v1_tag(&self) -> Option<&'static RsdpV1Tag> {
+    pub fn rsdp_v1_tag<'a>(&self) -> Option<&'a RsdpV1Tag> {
         self.get_tag(14).map(|tag| unsafe { &*(tag as *const Tag as *const RsdpV1Tag) })
     }
 
-    pub fn rsdp_v2_tag(&self) -> Option<&'static RsdpV2Tag> {
+    pub fn rsdp_v2_tag<'a>(&'a self) -> Option<&'a RsdpV2Tag> {
         self.get_tag(15).map(|tag| unsafe { &*(tag as *const Tag as *const RsdpV2Tag) })
     }
 
@@ -106,12 +106,12 @@ impl BootInformation {
         unsafe { &*self.inner }
     }
 
-    fn get_tag(&self, typ: u32) -> Option<&'static Tag> {
+    fn get_tag<'a>(&'a self, typ: u32) -> Option<&'a Tag> {
         self.tags().find(|tag| tag.typ == typ)
     }
 
     fn tags(&self) -> TagIter {
-        TagIter { current: unsafe { self.inner.offset(1) } as *const _ }
+        TagIter::new(unsafe { self.inner.offset(1) } as *const _)
     }
 }
 

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 #[derive(Debug)]
 #[repr(C)]
 pub struct MemoryMapTag {
@@ -16,6 +18,7 @@ impl MemoryMapTag {
             current_area: start_area as u64,
             last_area: (self_ptr as u64 + (self.size - self.entry_size) as u64),
             entry_size: self.entry_size,
+            phantom: PhantomData,
         }
     }
 }
@@ -44,15 +47,16 @@ impl MemoryArea {
 }
 
 #[derive(Clone, Debug)]
-pub struct MemoryAreaIter {
+pub struct MemoryAreaIter<'a> {
     current_area: u64,
     last_area: u64,
     entry_size: u32,
+    phantom: PhantomData<&'a MemoryArea>,
 }
 
-impl Iterator for MemoryAreaIter {
-    type Item = &'static MemoryArea;
-    fn next(&mut self) -> Option<&'static MemoryArea> {
+impl<'a> Iterator for MemoryAreaIter<'a> {
+    type Item = &'a MemoryArea;
+    fn next(&mut self) -> Option<&'a MemoryArea> {
         if self.current_area > self.last_area {
             None
         } else {

--- a/src/module.rs
+++ b/src/module.rs
@@ -37,14 +37,14 @@ pub fn module_iter(iter: TagIter) -> ModuleIter {
 }
 
 #[derive(Clone, Debug)]
-pub struct ModuleIter {
-    iter: TagIter,
+pub struct ModuleIter<'a> {
+    iter: TagIter<'a>,
 }
 
-impl Iterator for ModuleIter {
-    type Item = &'static ModuleTag;
+impl<'a> Iterator for ModuleIter<'a> {
+    type Item = &'a ModuleTag;
 
-    fn next(&mut self) -> Option<&'static ModuleTag> {
+    fn next(&mut self) -> Option<&'a ModuleTag> {
         self.iter.find(|x| x.typ == 3)
             .map(|tag| unsafe{&*(tag as *const Tag as *const ModuleTag)})
     }


### PR DESCRIPTION
Redid PR #31.
The code builds and passes all automated tests of the repo, but I didn’t test it using another project or similar. The many unsafe blocks doing pointer dereferencing and such hide stuff from the lifetime-checker. So simply because it builds is not yet assuring to me. Please check and test before merging.

I made an API change to `TagIter`, requiring the use of a constructor function.

I am sure that I haven’t captured the intention of issue #22 completely. Although, all handed-out references have some parametric lifetime, this patch doesn’t improve “safety”. Meaning: out-of-bounds accesses aren’t prevented and the multiboot2 header can’t be at an arbitrary place in memory, because the physical addresses inside the header are still directly interpreted as pointers.