### PR TITLE
Publish v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multiboot2"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Philipp Oppermann <dev@phil-opp.com>", "Calvin Lee <cyrus296@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental Multiboot 2 crate for ELF-64/32 kernels."


### PR DESCRIPTION
This includes the changes from #57.

@rust-osdev/multiboot2 could I get a review here, after which I'll publish the changes to crates.io