### PR TITLE
Add some basic documentation

### DIFF
--- a/src/boot_loader_name.rs
+++ b/src/boot_loader_name.rs
@@ -16,7 +16,7 @@ impl BootLoaderNameTag {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// if let Some(tag) = boot_info.boot_loader_name_tag() {
     ///     let name = tag.name();
     ///     // println!("Booted by: {:?}!", name);

--- a/src/boot_loader_name.rs
+++ b/src/boot_loader_name.rs
@@ -1,4 +1,8 @@
 
+/// This Tag contains the name of the bootloader that is booting the kernel.
+///
+/// The name is a normal C-style UTF-8 zero-terminated string that can be
+/// obtained via the `name` method.
 #[derive(Clone, Copy, Debug)]
 #[repr(C, packed)] // only repr(C) would add unwanted padding before first_section
 pub struct BootLoaderNameTag {
@@ -8,6 +12,16 @@ pub struct BootLoaderNameTag {
 }
 
 impl BootLoaderNameTag {
+    /// Read the name of the bootloader that is booting the kernel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// if let Some(tag) = boot_info.boot_loader_name_tag() {
+    ///     let name = tag.name();
+    ///     // println!("Booted by: {:?}!", name);
+    /// }
+    /// ```
     pub fn name(&self) -> &str {
         use core::{mem,str,slice};
         unsafe {

--- a/src/boot_loader_name.rs
+++ b/src/boot_loader_name.rs
@@ -19,7 +19,7 @@ impl BootLoaderNameTag {
     /// ```ignore
     /// if let Some(tag) = boot_info.boot_loader_name_tag() {
     ///     let name = tag.name();
-    ///     // println!("Booted by: {:?}!", name);
+    ///     assert_eq!("GRUB 2.02~beta3-5", name);
     /// }
     /// ```
     pub fn name(&self) -> &str {

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -18,7 +18,7 @@ impl CommandLineTag {
     /// ```ignore
     /// if let Some(tag) = boot_info.command_line_tag() {
     ///     let command_line = tag.command_line();
-    ///     // println!("Command line: {:?}!", command_line);
+    ///     assert_eq!("/bootarg", command_line);
     /// }
     /// ```
     pub fn command_line(&self) -> &str {

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -15,7 +15,7 @@ impl CommandLineTag {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// if let Some(tag) = boot_info.command_line_tag() {
     ///     let command_line = tag.command_line();
     ///     // println!("Command line: {:?}!", command_line);

--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -1,4 +1,7 @@
-
+/// This Tag contains the command line string.
+///
+/// The string is a normal C-style UTF-8 zero-terminated string that can be
+/// obtained via the `command_line` method.
 #[derive(Clone, Copy, Debug)]
 #[repr(C, packed)] // only repr(C) would add unwanted padding before first_section
 pub struct CommandLineTag {
@@ -8,6 +11,16 @@ pub struct CommandLineTag {
 }
 
 impl CommandLineTag {
+    /// Read the command line string that is being passed to the booting kernel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// if let Some(tag) = boot_info.command_line_tag() {
+    ///     let command_line = tag.command_line();
+    ///     // println!("Command line: {:?}!", command_line);
+    /// }
+    /// ```
     pub fn command_line(&self) -> &str {
         use core::{mem,str,slice};
         unsafe {

--- a/src/elf_sections.rs
+++ b/src/elf_sections.rs
@@ -1,5 +1,8 @@
 use header::Tag;
 
+/// This tag contains section header table from an ELF kernel.
+///
+/// The sections iterator is provided via the `sections` method.
 #[derive(Debug)]
 pub struct ElfSectionsTag {
     inner: *const ElfSectionsTagInner,
@@ -25,6 +28,19 @@ struct ElfSectionsTagInner {
 }
 
 impl ElfSectionsTag {
+    /// Get an iterator of loaded ELF sections.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// if let Some(elf_tag) = boot_info.elf_sections_tag() {
+    ///     let mut total = 0;
+    ///     for section in elf_tag.sections() {
+    ///         println!("Section: {:?}", section);
+    ///         total += 1;
+    ///     }
+    /// }
+    /// ```
     pub fn sections(&self) -> ElfSectionIter {
         let string_section_offset = (self.get().shndx * self.get().entry_size) as isize;
         let string_section_ptr = unsafe {
@@ -48,6 +64,7 @@ impl ElfSectionsTag {
     }
 }
 
+/// An iterator over some elf sections.
 #[derive(Clone, Debug)]
 pub struct ElfSectionIter {
     current_section: *const u8,
@@ -80,6 +97,7 @@ impl Iterator for ElfSectionIter {
     }
 }
 
+/// A single generic ELF Section.
 #[derive(Debug)]
 pub struct ElfSection {
     inner: *const u8,
@@ -119,6 +137,7 @@ struct ElfSectionInner64 {
 }
 
 impl ElfSection {
+    /// Get the section type as a `ElfSectionType` enum variant.
     pub fn section_type(&self) -> ElfSectionType {
         match self.get().typ() {
             0 => ElfSectionType::Unused,
@@ -139,10 +158,12 @@ impl ElfSection {
         }
     }
 
+    /// Get the "raw" section type as a `u32`
     pub fn section_type_raw(&self) -> u32 {
         self.get().typ()
     }
 
+    /// Read the name of the section from the string table and an offset.
     pub fn name(&self) -> &str {
         use core::{str, slice};
 
@@ -160,26 +181,39 @@ impl ElfSection {
         str::from_utf8(unsafe { slice::from_raw_parts(name_ptr, strlen) }).unwrap()
     }
 
+    /// Get the physical start address of the section.
     pub fn start_address(&self) -> u64 {
         self.get().addr()
     }
 
+    /// Get the physical end address of the section.
+    ///
+    /// This is the same as doing `section.start_address() + section.size()`
     pub fn end_address(&self) -> u64 {
         self.get().addr() + self.get().size()
     }
 
+    /// This member gives the section's size in bytes.
     pub fn size(&self) -> u64 {
         self.get().size()
     }
 
+    /// Get the sections address alignment constraints.
+    ///
+    /// That is, the value of `start_address` must be congruent to 0,
+    /// modulo the value of `addrlign`. Currently, only 0 and positive
+    /// integral powers of two are allowed. Values 0 and 1 mean the section has no
+    /// alignment constraints.
     pub fn addralign(&self) -> u64 {
         self.get().addralign()
     }
 
+    /// Get the sections flags.
     pub fn flags(&self) -> ElfSectionFlags {
         ElfSectionFlags::from_bits_truncate(self.get().flags())
     }
 
+    /// Check if the `ALLOCATED` flag is set in the section flags.
     pub fn is_allocated(&self) -> bool {
         self.flags().contains(ElfSectionFlags::ALLOCATED)
     }
@@ -268,29 +302,72 @@ impl ElfSectionInner for ElfSectionInner64 {
     }
 }
 
+/// An enum abstraction over raw ELF section types.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 #[repr(u32)]
 pub enum ElfSectionType {
+    /// This value marks the section header as inactive; it does not have an
+    /// associated section. Other members of the section header have undefined
+    /// values.
     Unused = 0,
+
+    /// The section holds information defined by the program, whose format and
+    /// meaning are determined solely by the program.
     ProgramSection = 1,
+
+    /// This section holds a symbol table.
     LinkerSymbolTable = 2,
+
+    /// The section holds a string table.
     StringTable = 3,
+
+    /// The section holds relocation entries with explicit addends, such as type
+    /// Elf32_Rela for the 32-bit class of object files. An object file may have
+    /// multiple relocation sections.
     RelaRelocation = 4,
+
+    /// The section holds a symbol hash table.
     SymbolHashTable = 5,
+
+    /// The section holds information for dynamic linking.
     DynamicLinkingTable = 6,
+
+    /// This section holds information that marks the file in some way.
     Note = 7,
+
+    /// A section of this type occupies no space in the file but otherwise resembles
+    /// SHT_PROGBITS. Although this section contains no bytes, the
+    /// sh_offset member contains the conceptual file offset.
     Uninitialized = 8,
+
+    /// The section holds relocation entries without explicit addends, such as type
+    /// Elf32_Rel for the 32-bit class of object files. An object file may have
+    /// multiple relocation sections.
     RelRelocation = 9,
+
+    /// This section type is reserved but has unspecified semantics.
     Reserved = 10,
+
+    /// This section holds a symbol table.
     DynamicLoaderSymbolTable = 11,
+
+    /// Values in this inclusive range are reserved for environment-specific semantics.
     EnvironmentSpecific = 0x6000_0000,
+
+    /// Values in this inclusive range are reserved for processor-specific semantics.
     ProcessorSpecific = 0x7000_0000,
 }
 
 bitflags! {
+    /// ELF Section bitflags.
     pub struct ElfSectionFlags: u64 {
+        /// The section contains data that should be writable during program execution.
         const WRITABLE = 0x1;
+
+        /// The section occupies memory during the process execution.
         const ALLOCATED = 0x2;
+
+        /// The section contains executable machine instructions.
         const EXECUTABLE = 0x4;
         // plus environment-specific use at 0x0F000000
         // plus processor-specific use at 0xF0000000

--- a/src/elf_sections.rs
+++ b/src/elf_sections.rs
@@ -32,7 +32,7 @@ impl ElfSectionsTag {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// if let Some(elf_tag) = boot_info.elf_sections_tag() {
     ///     let mut total = 0;
     ///     for section in elf_tag.sections() {

--- a/src/elf_sections.rs
+++ b/src/elf_sections.rs
@@ -64,7 +64,7 @@ impl ElfSectionsTag {
     }
 }
 
-/// An iterator over some elf sections.
+/// An iterator over some ELF sections.
 #[derive(Clone, Debug)]
 pub struct ElfSectionIter {
     current_section: *const u8,
@@ -163,7 +163,7 @@ impl ElfSection {
         self.get().typ()
     }
 
-    /// Read the name of the section from the string table and an offset.
+    /// Read the name of the section.
     pub fn name(&self) -> &str {
         use core::{str, slice};
 
@@ -193,12 +193,12 @@ impl ElfSection {
         self.get().addr() + self.get().size()
     }
 
-    /// This member gives the section's size in bytes.
+    /// Get the section's size in bytes.
     pub fn size(&self) -> u64 {
         self.get().size()
     }
 
-    /// Get the sections address alignment constraints.
+    /// Get the section's address alignment constraints.
     ///
     /// That is, the value of `start_address` must be congruent to 0,
     /// modulo the value of `addrlign`. Currently, only 0 and positive
@@ -208,7 +208,7 @@ impl ElfSection {
         self.get().addralign()
     }
 
-    /// Get the sections flags.
+    /// Get the section's flags.
     pub fn flags(&self) -> ElfSectionFlags {
         ElfSectionFlags::from_bits_truncate(self.get().flags())
     }
@@ -315,7 +315,7 @@ pub enum ElfSectionType {
     /// meaning are determined solely by the program.
     ProgramSection = 1,
 
-    /// This section holds a symbol table.
+    /// This section holds a linker symbol table.
     LinkerSymbolTable = 2,
 
     /// The section holds a string table.
@@ -329,14 +329,14 @@ pub enum ElfSectionType {
     /// The section holds a symbol hash table.
     SymbolHashTable = 5,
 
-    /// The section holds information for dynamic linking.
+    /// The section holds dynamic linking tables.
     DynamicLinkingTable = 6,
 
     /// This section holds information that marks the file in some way.
     Note = 7,
 
     /// A section of this type occupies no space in the file but otherwise resembles
-    /// SHT_PROGBITS. Although this section contains no bytes, the
+    /// `ProgramSection`. Although this section contains no bytes, the
     /// sh_offset member contains the conceptual file offset.
     Uninitialized = 8,
 
@@ -348,13 +348,15 @@ pub enum ElfSectionType {
     /// This section type is reserved but has unspecified semantics.
     Reserved = 10,
 
-    /// This section holds a symbol table.
+    /// This section holds a dynamic loader symbol table.
     DynamicLoaderSymbolTable = 11,
 
-    /// Values in this inclusive range are reserved for environment-specific semantics.
+    /// Values in this inclusive range (`[0x6000_0000, 0x6FFF_FFFF)`) are
+    /// reserved for environment-specific semantics.
     EnvironmentSpecific = 0x6000_0000,
 
-    /// Values in this inclusive range are reserved for processor-specific semantics.
+    /// Values in this inclusive range (`[0x7000_0000, 0x7FFF_FFFF)`) are
+    /// reserved for processor-specific semantics.
     ProcessorSpecific = 0x7000_0000,
 }
 

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -2,40 +2,79 @@ use header::Tag;
 use ::Reader;
 use core::slice;
 
+/// The VBE Framebuffer information Tag.
 #[derive(Debug, PartialEq)]
 pub struct FramebufferTag<'a> {
+    /// Contains framebuffer physical address.
+    ///
+    /// This field is 64-bit wide but bootloader should set it under 4GiB if
+    /// possible for compatibility with payloads which aren’t aware of PAE or
+    /// amd64.
     pub address: u64,
+
+    /// Contains the pitch in bytes.
     pub pitch: u32,
+
+    /// Contain framebuffer width in pixels.
     pub width: u32,
+
+    /// Contain framebuffer height in pixels.
     pub height: u32,
+
+    /// Contains number of bits per pixel.
     pub bpp: u8,
+
+    /// The type of framebuffer, one of: Indexed, RGB or Text.
     pub buffer_type: FramebufferType<'a>
 }
 
+/// The type of framebuffer.
 #[derive(Debug, PartialEq)]
 pub enum FramebufferType<'a> {
+    /// Indexed color.
     Indexed {
+        #[allow(missing_docs)]
         palette: &'a [FramebufferColor]
     },
+
+    /// Direct RGB color.
+    #[allow(missing_docs)]
     RGB {
         red: FramebufferField,
         green: FramebufferField,
         blue: FramebufferField
     },
+
+    /// EGA Text.
+    ///
+    /// In this case the framebuffer width and height are expressed in
+    /// characters and not in pixels.
+    ///
+    /// The bpp is equal 16 (16 bits per character) and pitch is expressed in bytes per text line.
     Text
 }
 
+/// An RGB color type field.
 #[derive(Debug, PartialEq)]
 pub struct FramebufferField {
+    /// Color field position.
     pub position: u8,
+
+    /// Color mask size.
     pub size: u8
 }
 
+/// A framebuffer color descriptor in the palette.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(C, packed)]
 pub struct FramebufferColor {
+    /// The amount of Red.
     pub red: u8,
+
+    /// The amount of Green.
     pub green: u8,
+
+    /// The amount of Blue.
     pub blue: u8
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! # Examples
 //!
-//! ```
+//! ```ignore
 //! use multiboot2::load;
 //!
 //! // The Multiboot 2 specification dictates that the machine state after the
@@ -54,7 +54,7 @@ mod vbe_info;
 ///
 /// Examples
 ///
-/// ```
+/// ```ignore
 /// use multiboot::load;
 ///
 /// fn kmain(multiboot_info_ptr: u32) {
@@ -74,7 +74,7 @@ pub unsafe fn load(address: usize) -> BootInformation {
 ///
 /// Examples
 ///
-/// ```
+/// ```ignore
 /// use multiboot::load;
 ///
 /// let ptr = 0xDEADBEEF as *const _;
@@ -114,7 +114,7 @@ impl BootInformation {
     ///
     /// This is the same as doing:
     ///
-    /// ```
+    /// ```ignore
     /// let end_addr = boot_info.start_address() + boot_info.size();
     /// ```
     pub fn end_address(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! An experimental Multiboot 2 crate for ELF-64/32 kernels.
 //!
-//! The GNU Multiboot specification aims provide a standardised
+//! The GNU Multiboot specification aims provide to a standardised
 //! method of sharing commonly used information about the host machine at
 //! boot time.
 //!
@@ -23,28 +23,32 @@
 
 use core::fmt;
 
-use header::{Tag, TagIter};
 pub use boot_loader_name::BootLoaderNameTag;
-pub use elf_sections::{ElfSectionsTag, ElfSection, ElfSectionIter, ElfSectionType, ElfSectionFlags};
-pub use framebuffer::{FramebufferTag, FramebufferType, FramebufferField, FramebufferColor};
-pub use memory_map::{MemoryMapTag, MemoryArea, MemoryAreaType, MemoryAreaIter};
-pub use module::{ModuleTag, ModuleIter};
 pub use command_line::CommandLineTag;
+pub use elf_sections::{
+    ElfSection, ElfSectionFlags, ElfSectionIter, ElfSectionType, ElfSectionsTag,
+};
+pub use framebuffer::{FramebufferColor, FramebufferField, FramebufferTag, FramebufferType};
+use header::{Tag, TagIter};
+pub use memory_map::{MemoryArea, MemoryAreaIter, MemoryAreaType, MemoryMapTag};
+pub use module::{ModuleIter, ModuleTag};
 pub use rsdp::{RsdpV1Tag, RsdpV2Tag};
-pub use vbe_info::{VBEInfoTag, VBEControlInfo, VBEModeInfo, VBEField, VBECapabilities, 
-                   VBEModeAttributes, VBEWindowAttributes, VBEDirectColorAttributes, VBEMemoryModel};
+pub use vbe_info::{
+    VBECapabilities, VBEControlInfo, VBEDirectColorAttributes, VBEField, VBEInfoTag,
+    VBEMemoryModel, VBEModeAttributes, VBEModeInfo, VBEWindowAttributes,
+};
 
 #[macro_use]
 extern crate bitflags;
 
-mod header;
 mod boot_loader_name;
+mod command_line;
 mod elf_sections;
+mod framebuffer;
+mod header;
 mod memory_map;
 mod module;
-mod command_line;
 mod rsdp;
-mod framebuffer;
 mod vbe_info;
 
 /// Load the multiboot boot information struct from an address.
@@ -67,7 +71,10 @@ pub unsafe fn load(address: usize) -> BootInformation {
     let multiboot = &*(address as *const BootInformationInner);
     assert_eq!(0, multiboot.total_size & 0b111);
     assert!(multiboot.has_valid_end_tag());
-    BootInformation { inner: multiboot, offset: 0 }
+    BootInformation {
+        inner: multiboot,
+        offset: 0,
+    }
 }
 
 /// Load the multiboot boot information struct from an address at an offset.
@@ -89,7 +96,10 @@ pub unsafe fn load_with_offset(address: usize, offset: usize) -> BootInformation
     let multiboot = &*((address + offset) as *const BootInformationInner);
     assert_eq!(0, multiboot.total_size & 0b111);
     assert!(multiboot.has_valid_end_tag());
-    BootInformation { inner: multiboot, offset: offset }
+    BootInformation {
+        inner: multiboot,
+        offset: offset,
+    }
 }
 
 /// A Multiboot 2 Boot Information struct.
@@ -128,14 +138,14 @@ impl BootInformation {
 
     /// Search for the ELF Sections tag.
     pub fn elf_sections_tag(&self) -> Option<ElfSectionsTag> {
-        self.get_tag(9).map(|tag| unsafe {
-            elf_sections::elf_sections_tag(tag, self.offset)
-        })
+        self.get_tag(9)
+            .map(|tag| unsafe { elf_sections::elf_sections_tag(tag, self.offset) })
     }
 
     /// Search for the Memory map tag.
     pub fn memory_map_tag<'a>(&'a self) -> Option<&'a MemoryMapTag> {
-        self.get_tag(6).map(|tag| unsafe { &*(tag as *const Tag as *const MemoryMapTag) })
+        self.get_tag(6)
+            .map(|tag| unsafe { &*(tag as *const Tag as *const MemoryMapTag) })
     }
 
     /// Get an iterator of all module tags.
@@ -145,12 +155,14 @@ impl BootInformation {
 
     /// Search for the BootLoader name tag.
     pub fn boot_loader_name_tag<'a>(&'a self) -> Option<&'a BootLoaderNameTag> {
-        self.get_tag(2).map(|tag| unsafe { &*(tag as *const Tag as *const BootLoaderNameTag) })
+        self.get_tag(2)
+            .map(|tag| unsafe { &*(tag as *const Tag as *const BootLoaderNameTag) })
     }
 
-    /// Search for the Memory map tag.
+    /// Search for the Command line tag.
     pub fn command_line_tag<'a>(&'a self) -> Option<&'a CommandLineTag> {
-        self.get_tag(1).map(|tag| unsafe { &*(tag as *const Tag as *const CommandLineTag) })
+        self.get_tag(1)
+            .map(|tag| unsafe { &*(tag as *const Tag as *const CommandLineTag) })
     }
 
     /// Search for the VBE framebuffer tag.
@@ -160,17 +172,20 @@ impl BootInformation {
 
     /// Search for the (ACPI 1.0) RSDP tag.
     pub fn rsdp_v1_tag<'a>(&self) -> Option<&'a RsdpV1Tag> {
-        self.get_tag(14).map(|tag| unsafe { &*(tag as *const Tag as *const RsdpV1Tag) })
+        self.get_tag(14)
+            .map(|tag| unsafe { &*(tag as *const Tag as *const RsdpV1Tag) })
     }
 
     /// Search for the (ACPI 2.0 or later) RSDP tag.
     pub fn rsdp_v2_tag<'a>(&'a self) -> Option<&'a RsdpV2Tag> {
-        self.get_tag(15).map(|tag| unsafe { &*(tag as *const Tag as *const RsdpV2Tag) })
+        self.get_tag(15)
+            .map(|tag| unsafe { &*(tag as *const Tag as *const RsdpV2Tag) })
     }
 
     /// Search for the VBE information tag.
     pub fn vbe_info_tag(&self) -> Option<&'static VBEInfoTag> {
-        self.get_tag(7).map(|tag| unsafe { &*(tag as *const Tag as *const VBEInfoTag) })
+        self.get_tag(7)
+            .map(|tag| unsafe { &*(tag as *const Tag as *const VBEInfoTag) })
     }
 
     fn get(&self) -> &BootInformationInner {
@@ -202,8 +217,13 @@ impl fmt::Debug for BootInformation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "multiboot information")?;
 
-        writeln!(f, "S: {:#010X}, E: {:#010X}, L: {:#010X}",
-            self.start_address(), self.end_address(), self.total_size())?;
+        writeln!(
+            f,
+            "S: {:#010X}, E: {:#010X}, L: {:#010X}",
+            self.start_address(),
+            self.end_address(),
+            self.total_size()
+        )?;
 
         if let Some(boot_loader_name_tag) = self.boot_loader_name_tag() {
             writeln!(f, "boot loader name: {}", boot_loader_name_tag.name())?;
@@ -216,24 +236,40 @@ impl fmt::Debug for BootInformation {
         if let Some(memory_map_tag) = self.memory_map_tag() {
             writeln!(f, "memory areas:")?;
             for area in memory_map_tag.memory_areas() {
-                writeln!(f, "    S: {:#010X}, E: {:#010X}, L: {:#010X}",
-                    area.start_address(), area.end_address(), area.size())?;
+                writeln!(
+                    f,
+                    "    S: {:#010X}, E: {:#010X}, L: {:#010X}",
+                    area.start_address(),
+                    area.end_address(),
+                    area.size()
+                )?;
             }
         }
 
         if let Some(elf_sections_tag) = self.elf_sections_tag() {
             writeln!(f, "kernel sections:")?;
             for s in elf_sections_tag.sections() {
-                writeln!(f, "    name: {:15}, S: {:#08X}, E: {:#08X}, L: {:#08X}, F: {:#04X}",
-                    s.name(), s.start_address(),
-                    s.start_address() + s.size(), s.size(), s.flags().bits())?;
+                writeln!(
+                    f,
+                    "    name: {:15}, S: {:#08X}, E: {:#08X}, L: {:#08X}, F: {:#04X}",
+                    s.name(),
+                    s.start_address(),
+                    s.start_address() + s.size(),
+                    s.size(),
+                    s.flags().bits()
+                )?;
             }
         }
 
         writeln!(f, "module tags:")?;
         for mt in self.module_tags() {
-            writeln!(f, "    name: {:15}, S: {:#010X}, E: {:#010X}",
-                mt.name(), mt.start_address(), mt.end_address())?;
+            writeln!(
+                f,
+                "    name: {:15}, S: {:#010X}, E: {:#010X}",
+                mt.name(),
+                mt.start_address(),
+                mt.end_address()
+            )?;
         }
 
         Ok(())
@@ -242,22 +278,20 @@ impl fmt::Debug for BootInformation {
 
 pub(crate) struct Reader {
     pub(crate) ptr: *const u8,
-    pub(crate) off: usize
+    pub(crate) off: usize,
 }
 
 impl Reader {
     pub(crate) fn new<T>(ptr: *const T) -> Reader {
         Reader {
             ptr: ptr as *const u8,
-            off: 0
+            off: 0,
         }
     }
 
     pub(crate) fn read_u8(&mut self) -> u8 {
         self.off += 1;
-        unsafe {
-            core::ptr::read(self.ptr.offset((self.off - 1) as isize))
-        }
+        unsafe { core::ptr::read(self.ptr.offset((self.off - 1) as isize)) }
     }
 
     pub(crate) fn read_u16(&mut self) -> u16 {
@@ -277,18 +311,16 @@ impl Reader {
     }
 
     pub(crate) fn current_address(&self) -> usize {
-        unsafe {
-            self.ptr.offset(self.off as isize) as usize
-        }
+        unsafe { self.ptr.offset(self.off as isize) as usize }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{load, load_with_offset};
-    use super::{BootInformation, ElfSectionFlags, ElfSectionType};
     use super::FramebufferType;
     use super::MemoryAreaType;
+    use super::{load, load_with_offset};
+    use super::{BootInformation, ElfSectionFlags, ElfSectionType};
 
     #[test]
     fn no_tags() {
@@ -296,9 +328,9 @@ mod tests {
         struct Bytes([u8; 16]);
         let bytes: Bytes = Bytes([
             16, 0, 0, 0, // total_size
-            0, 0, 0, 0,  // reserved
-            0, 0, 0, 0,  // end tag type
-            8, 0, 0, 0,  // end tag size
+            0, 0, 0, 0, // reserved
+            0, 0, 0, 0, // end tag type
+            8, 0, 0, 0, // end tag size
         ]);
         let addr = bytes.0.as_ptr() as usize;
         let bi = unsafe { load(addr) };
@@ -311,7 +343,6 @@ mod tests {
         assert!(bi.boot_loader_name_tag().is_none());
         assert!(bi.command_line_tag().is_none());
     }
-
 
     #[test]
     #[should_panic]
@@ -320,9 +351,9 @@ mod tests {
         struct Bytes([u8; 15]);
         let bytes: Bytes = Bytes([
             15, 0, 0, 0, // total_size
-            0, 0, 0, 0,  // reserved
-            0, 0, 0, 0,  // end tag type
-            8, 0, 0,     // end tag size
+            0, 0, 0, 0, // reserved
+            0, 0, 0, 0, // end tag type
+            8, 0, 0, // end tag size
         ]);
         let addr = bytes.0.as_ptr() as usize;
         let bi = unsafe { load(addr) };
@@ -336,7 +367,6 @@ mod tests {
         assert!(bi.command_line_tag().is_none());
     }
 
-
     #[test]
     #[should_panic]
     fn invalid_end_tag() {
@@ -344,9 +374,9 @@ mod tests {
         struct Bytes([u8; 16]);
         let bytes: Bytes = Bytes([
             16, 0, 0, 0, // total_size
-            0, 0, 0, 0,  // reserved
-            0, 0, 0, 0,  // end tag type
-            9, 0, 0, 0,  // end tag size
+            0, 0, 0, 0, // reserved
+            0, 0, 0, 0, // end tag type
+            9, 0, 0, 0, // end tag size
         ]);
         let addr = bytes.0.as_ptr() as usize;
         let bi = unsafe { load(addr) };
@@ -365,14 +395,14 @@ mod tests {
         #[repr(C, align(8))]
         struct Bytes([u8; 32]);
         let bytes: Bytes = Bytes([
-            32, 0, 0, 0,       // total_size
-            0, 0, 0, 0,        // reserved
-            2, 0, 0, 0,        // boot loader name tag type
-            13, 0, 0, 0,       // boot loader name tag size
+            32, 0, 0, 0, // total_size
+            0, 0, 0, 0, // reserved
+            2, 0, 0, 0, // boot loader name tag type
+            13, 0, 0, 0, // boot loader name tag size
             110, 97, 109, 101, // boot loader name 'name'
-            0, 0, 0, 0,        // boot loader name null + padding
-            0, 0, 0, 0,        // end tag type
-            8, 0, 0, 0,        // end tag size
+            0, 0, 0, 0, // boot loader name null + padding
+            0, 0, 0, 0, // end tag type
+            8, 0, 0, 0, // end tag size
         ]);
         let addr = bytes.0.as_ptr() as usize;
         let bi = unsafe { load(addr) };
@@ -394,45 +424,51 @@ mod tests {
         #[repr(C, align(8))]
         struct Bytes([u8; 56]);
         let bytes: Bytes = Bytes([
-            56, 0, 0, 0,  // total size
-            0, 0, 0, 0,   // reserved
-            8, 0, 0, 0,   // framebuffer tag type
-            40, 0, 0, 0,  // framebuffer tag size
+            56, 0, 0, 0, // total size
+            0, 0, 0, 0, // reserved
+            8, 0, 0, 0, // framebuffer tag type
+            40, 0, 0, 0, // framebuffer tag size
             0, 0, 0, 253, // framebuffer low dword of address
-            0, 0, 0, 0,   // framebuffer high dword of address
-            0, 20, 0, 0,  // framebuffer pitch
-            0, 5, 0, 0,   // framebuffer width
+            0, 0, 0, 0, // framebuffer high dword of address
+            0, 20, 0, 0, // framebuffer pitch
+            0, 5, 0, 0, // framebuffer width
             208, 2, 0, 0, // framebuffer height
-            32, 1, 0, 0,  // framebuffer bpp, type, reserved word
-            16, 8, 8, 8,  // framebuffer red pos/size, green pos/size
-            0, 8, 0, 0,   // framebuffer blue pos/size, padding word
-            0, 0, 0, 0,   // end tag type
-            8, 0, 0, 0    // end tag size
+            32, 1, 0, 0, // framebuffer bpp, type, reserved word
+            16, 8, 8, 8, // framebuffer red pos/size, green pos/size
+            0, 8, 0, 0, // framebuffer blue pos/size, padding word
+            0, 0, 0, 0, // end tag type
+            8, 0, 0, 0, // end tag size
         ]);
         let addr = bytes.0.as_ptr() as usize;
         let bi = unsafe { load(addr) };
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        use framebuffer::{FramebufferTag, FramebufferField, FramebufferType};
-        assert_eq!(bi.framebuffer_tag(), Some(FramebufferTag {
-            address: 4244635648,
-            pitch: 5120,
-            width: 1280,
-            height: 720,
-            bpp: 32,
-            buffer_type: FramebufferType::RGB {
-                red: FramebufferField {
-                    position: 16, size: 8
-                },
-                green: FramebufferField {
-                    position: 8, size: 8
-                },
-                blue: FramebufferField {
-                    position: 0, size: 8
+        use framebuffer::{FramebufferField, FramebufferTag, FramebufferType};
+        assert_eq!(
+            bi.framebuffer_tag(),
+            Some(FramebufferTag {
+                address: 4244635648,
+                pitch: 5120,
+                width: 1280,
+                height: 720,
+                bpp: 32,
+                buffer_type: FramebufferType::RGB {
+                    red: FramebufferField {
+                        position: 16,
+                        size: 8
+                    },
+                    green: FramebufferField {
+                        position: 8,
+                        size: 8
+                    },
+                    blue: FramebufferField {
+                        position: 0,
+                        size: 8
+                    }
                 }
-            }
-        }))
+            })
+        )
     }
 
     #[test]
@@ -443,29 +479,27 @@ mod tests {
         #[repr(C, align(8))]
         struct Bytes([u8; 64]);
         let bytes: Bytes = Bytes([
-            64, 0, 0, 0,  // total size
-            0, 0, 0, 0,   // reserved
-            8, 0, 0, 0,   // framebuffer tag type
-            48, 0, 0, 0,  // framebuffer tag size
+            64, 0, 0, 0, // total size
+            0, 0, 0, 0, // reserved
+            8, 0, 0, 0, // framebuffer tag type
+            48, 0, 0, 0, // framebuffer tag size
             0, 0, 0, 253, // framebuffer low dword of address
-            0, 0, 0, 0,   // framebuffer high dword of address
-            0, 20, 0, 0,  // framebuffer pitch
-            0, 5, 0, 0,   // framebuffer width
+            0, 0, 0, 0, // framebuffer high dword of address
+            0, 20, 0, 0, // framebuffer pitch
+            0, 5, 0, 0, // framebuffer width
             208, 2, 0, 0, // framebuffer height
-            32, 0, 0, 0,  // framebuffer bpp, type, reserved word
-            4, 0, 0, 0,   // framebuffer palette length
-            255, 0, 0, 0,  // framebuffer palette
-            255, 0, 0, 0,
-            255, 0, 0, 0, 
-            0, 0, 0, 0,   // end tag type
-            8, 0, 0, 0    // end tag size
+            32, 0, 0, 0, // framebuffer bpp, type, reserved word
+            4, 0, 0, 0, // framebuffer palette length
+            255, 0, 0, 0, // framebuffer palette
+            255, 0, 0, 0, 255, 0, 0, 0, 0, 0, 0, 0, // end tag type
+            8, 0, 0, 0, // end tag size
         ]);
         let addr = bytes.0.as_ptr() as usize;
         let bi = unsafe { load(addr) };
         assert_eq!(addr, bi.start_address());
         assert_eq!(addr + bytes.0.len(), bi.end_address());
         assert_eq!(bytes.0.len(), bi.total_size());
-        use framebuffer::{FramebufferType, FramebufferColor};
+        use framebuffer::{FramebufferColor, FramebufferType};
         assert!(bi.framebuffer_tag().is_some());
         let fbi = bi.framebuffer_tag().unwrap();
         assert_eq!(fbi.address, 4244635648);
@@ -474,13 +508,32 @@ mod tests {
         assert_eq!(fbi.height, 720);
         assert_eq!(fbi.bpp, 32);
         match fbi.buffer_type {
-            FramebufferType::Indexed { palette } => assert_eq!(palette, [
-                FramebufferColor { red: 255, green: 0, blue: 0 },
-                FramebufferColor { red: 0, green: 255, blue: 0 },
-                FramebufferColor { red: 0, green: 0, blue: 255 },
-                FramebufferColor { red: 0, green: 0, blue: 0}
-            ]),
-            _ => panic!("Expected indexed framebuffer type.")
+            FramebufferType::Indexed { palette } => assert_eq!(
+                palette,
+                [
+                    FramebufferColor {
+                        red: 255,
+                        green: 0,
+                        blue: 0
+                    },
+                    FramebufferColor {
+                        red: 0,
+                        green: 255,
+                        blue: 0
+                    },
+                    FramebufferColor {
+                        red: 0,
+                        green: 0,
+                        blue: 255
+                    },
+                    FramebufferColor {
+                        red: 0,
+                        green: 0,
+                        blue: 0
+                    }
+                ]
+            ),
+            _ => panic!("Expected indexed framebuffer type."),
         }
     }
 
@@ -490,206 +543,67 @@ mod tests {
         #[repr(C, align(8))]
         struct Bytes([u8; 800]);
         let bytes = Bytes([
-            32, 3, 0, 0,        // Total size.
-            0, 0, 0, 0,         // Reserved
-            7, 0, 0, 0,         // Tag type.
-            16, 3, 0, 0,        // Tag size.
-            122, 65, 255, 255,  // VBE mode, protected mode interface segment,
-            0, 96, 79, 0,       // protected mode interface offset, and length.
-            86, 69, 83, 65,     // "VESA" signature.
-            0, 3, 220, 87,      // VBE version, lower half of OEM string ptr,
-            0, 192, 1, 0,       // upper half of OEM string ptr, lower half of capabilities
-            0, 0, 34, 128,      // upper half of capabilities, lower half of vide mode ptr,
-            0, 96, 0, 1,        // upper half of video mode ptr, number of 64kb memory blocks
-            0, 0, 240, 87,      // OEM software revision, lower half of OEM vendor string ptr,
-            0, 192, 3, 88,      // upper half of OEM vendor string ptr, lower half of OEM product string ptr,
-            0, 192, 23, 88,     // upper half of OEM product string ptr, lower half of OEM revision string ptr,
-            0, 192, 0, 1,       // upper half of OEM revision string ptr.
-            1, 1, 2, 1,         // Reserved data....
-            3, 1, 4, 1, 
-            5, 1, 6, 1, 
-            7, 1, 13, 1, 
-            14, 1, 15, 1, 
-            16, 1, 17, 1, 
-            18, 1, 19, 1, 
-            20, 1, 21, 1, 
-            22, 1, 23, 1, 
-            24, 1, 25, 1, 
-            26, 1, 27, 1, 
-            28, 1, 29, 1, 
-            30, 1, 31, 1, 
-            64, 1, 65, 1, 
-            66, 1, 67, 1, 
-            68, 1, 69, 1, 
-            70, 1, 71, 1, 
-            72, 1, 73, 1, 
-            74, 1, 75, 1, 
-            76, 1, 117, 1, 
-            118, 1, 119, 1, 
-            120, 1, 121, 1, 
-            122, 1, 123, 1, 
-            124, 1, 125, 1, 
-            126, 1, 127, 1, 
-            128, 1, 129, 1, 
-            130, 1, 131, 1, 
-            132, 1, 133, 1, 
-            134, 1, 135, 1, 
-            136, 1, 137, 1, 
-            138, 1, 139, 1, 
-            140, 1, 141, 1, 
-            142, 1, 143, 1, 
-            144, 1, 145, 1, 
-            146, 1, 0, 0, 
-            1, 0, 2, 0, 
-            3, 0, 4, 0, 
-            5, 0, 6, 0, 
-            7, 0, 13, 0, 
-            14, 0, 15, 0, 
-            16, 0, 17, 0, 
-            18, 0, 19, 0, 
-            106, 0, 255, 255, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0,         // Until Here
-            187, 0, 7, 0,       // Mode attributes, window A and B attributes
-            64, 0, 64, 0,       // Window granularity and size.
-            0, 160, 0, 0,       // Window A and B segments.
-            186, 84, 0, 192,    // Window relocation function pointer.
-            0, 20, 0, 5,        // Pitch, X resolution.
-            32, 3, 8, 16,       // Y resolution, X char size, Y char size.
-            1, 32, 1, 6,        // Number of planes, BPP, number of banks, memory model.
-            0, 3, 1, 8,         // Bank size, number of images, reserved, red mask size.
-            16, 8, 8, 8,        // Red mask position, green mask size, green mask position, blue mask size,
-            0, 8, 24, 2,        // blue mask position, reserved mask size, reserved mask position, color attributes.
-            0, 0, 0, 253,       // Frame buffer base address.
-            0, 0, 0, 0,         // Off screen memory offset.
-            0, 0, 0, 20,        // Off screen memory size, reserved data...
-            0, 0, 8, 16, 
-            8, 8, 8, 0, 
-            8, 24, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0, 
-            0, 0, 0, 0,         // Until here.
-            0, 0, 0, 0,         // End tag type.
-            8, 0, 0, 0          // End tag size.
+            32, 3, 0, 0, // Total size.
+            0, 0, 0, 0, // Reserved
+            7, 0, 0, 0, // Tag type.
+            16, 3, 0, 0, // Tag size.
+            122, 65, 255, 255, // VBE mode, protected mode interface segment,
+            0, 96, 79, 0, // protected mode interface offset, and length.
+            86, 69, 83, 65, // "VESA" signature.
+            0, 3, 220, 87, // VBE version, lower half of OEM string ptr,
+            0, 192, 1, 0, // upper half of OEM string ptr, lower half of capabilities
+            0, 0, 34, 128, // upper half of capabilities, lower half of vide mode ptr,
+            0, 96, 0, 1, // upper half of video mode ptr, number of 64kb memory blocks
+            0, 0, 240, 87, // OEM software revision, lower half of OEM vendor string ptr,
+            0, 192, 3,
+            88, // upper half of OEM vendor string ptr, lower half of OEM product string ptr,
+            0, 192, 23,
+            88, // upper half of OEM product string ptr, lower half of OEM revision string ptr,
+            0, 192, 0, 1, // upper half of OEM revision string ptr.
+            1, 1, 2, 1, // Reserved data....
+            3, 1, 4, 1, 5, 1, 6, 1, 7, 1, 13, 1, 14, 1, 15, 1, 16, 1, 17, 1, 18, 1, 19, 1, 20, 1,
+            21, 1, 22, 1, 23, 1, 24, 1, 25, 1, 26, 1, 27, 1, 28, 1, 29, 1, 30, 1, 31, 1, 64, 1, 65,
+            1, 66, 1, 67, 1, 68, 1, 69, 1, 70, 1, 71, 1, 72, 1, 73, 1, 74, 1, 75, 1, 76, 1, 117, 1,
+            118, 1, 119, 1, 120, 1, 121, 1, 122, 1, 123, 1, 124, 1, 125, 1, 126, 1, 127, 1, 128, 1,
+            129, 1, 130, 1, 131, 1, 132, 1, 133, 1, 134, 1, 135, 1, 136, 1, 137, 1, 138, 1, 139, 1,
+            140, 1, 141, 1, 142, 1, 143, 1, 144, 1, 145, 1, 146, 1, 0, 0, 1, 0, 2, 0, 3, 0, 4, 0,
+            5, 0, 6, 0, 7, 0, 13, 0, 14, 0, 15, 0, 16, 0, 17, 0, 18, 0, 19, 0, 106, 0, 255, 255, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // Until Here
+            187, 0, 7, 0, // Mode attributes, window A and B attributes
+            64, 0, 64, 0, // Window granularity and size.
+            0, 160, 0, 0, // Window A and B segments.
+            186, 84, 0, 192, // Window relocation function pointer.
+            0, 20, 0, 5, // Pitch, X resolution.
+            32, 3, 8, 16, // Y resolution, X char size, Y char size.
+            1, 32, 1, 6, // Number of planes, BPP, number of banks, memory model.
+            0, 3, 1, 8, // Bank size, number of images, reserved, red mask size.
+            16, 8, 8,
+            8, // Red mask position, green mask size, green mask position, blue mask size,
+            0, 8, 24,
+            2, // blue mask position, reserved mask size, reserved mask position, color attributes.
+            0, 0, 0, 253, // Frame buffer base address.
+            0, 0, 0, 0, // Off screen memory offset.
+            0, 0, 0, 20, // Off screen memory size, reserved data...
+            0, 0, 8, 16, 8, 8, 8, 0, 8, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, // Until here.
+            0, 0, 0, 0, // End tag type.
+            8, 0, 0, 0, // End tag size.
         ]);
 
         let addr = bytes.0.as_ptr() as usize;
@@ -708,7 +622,10 @@ mod tests {
             assert_eq!(vbe.control_info.signature, [86, 69, 83, 65]);
             assert_eq!(vbe.control_info.version, 768);
             assert_eq!(vbe.control_info.oem_string_ptr, 3221247964);
-            assert_eq!(vbe.control_info.capabilities, VBECapabilities::SWITCHABLE_DAC);
+            assert_eq!(
+                vbe.control_info.capabilities,
+                VBECapabilities::SWITCHABLE_DAC
+            );
             assert_eq!(vbe.control_info.mode_list_ptr, 1610645538);
             assert_eq!(vbe.control_info.total_memory, 256);
             assert_eq!(vbe.control_info.oem_software_revision, 0);
@@ -716,16 +633,16 @@ mod tests {
             assert_eq!(vbe.control_info.oem_product_name_ptr, 3221248003);
             assert_eq!(vbe.control_info.oem_product_revision_ptr, 3221248023);
             assert!(vbe.mode_info.mode_attributes.contains(
-                VBEModeAttributes::SUPPORTED 
-                | VBEModeAttributes::COLOR
-                | VBEModeAttributes::GRAPHICS
-                | VBEModeAttributes::NOT_VGA_COMPATIBLE
-                | VBEModeAttributes::LINEAR_FRAMEBUFFER
+                VBEModeAttributes::SUPPORTED
+                    | VBEModeAttributes::COLOR
+                    | VBEModeAttributes::GRAPHICS
+                    | VBEModeAttributes::NOT_VGA_COMPATIBLE
+                    | VBEModeAttributes::LINEAR_FRAMEBUFFER
             ));
             assert!(vbe.mode_info.window_a_attributes.contains(
                 VBEWindowAttributes::RELOCATABLE
-                | VBEWindowAttributes::READABLE
-                | VBEWindowAttributes::WRITEABLE
+                    | VBEWindowAttributes::READABLE
+                    | VBEWindowAttributes::WRITEABLE
             ));
             assert_eq!(vbe.mode_info.window_granularity, 64);
             assert_eq!(vbe.mode_info.window_size, 64);
@@ -740,19 +657,38 @@ mod tests {
             assert_eq!(vbe.mode_info.memory_model, VBEMemoryModel::DirectColor);
             assert_eq!(vbe.mode_info.bank_size, 0);
             assert_eq!(vbe.mode_info.number_of_image_pages, 3);
-            assert_eq!(vbe.mode_info.red_field, VBEField {
-                position: 16, size: 8
-            });
-            assert_eq!(vbe.mode_info.green_field, VBEField {
-                position: 8, size: 8
-            });
-            assert_eq!(vbe.mode_info.blue_field, VBEField {
-                position: 0, size: 8
-            });
-            assert_eq!(vbe.mode_info.reserved_field, VBEField {
-                position: 24, size: 8
-            });
-            assert_eq!(vbe.mode_info.direct_color_attributes, VBEDirectColorAttributes::RESERVED_USABLE);
+            assert_eq!(
+                vbe.mode_info.red_field,
+                VBEField {
+                    position: 16,
+                    size: 8
+                }
+            );
+            assert_eq!(
+                vbe.mode_info.green_field,
+                VBEField {
+                    position: 8,
+                    size: 8
+                }
+            );
+            assert_eq!(
+                vbe.mode_info.blue_field,
+                VBEField {
+                    position: 0,
+                    size: 8
+                }
+            );
+            assert_eq!(
+                vbe.mode_info.reserved_field,
+                VBEField {
+                    position: 24,
+                    size: 8
+                }
+            );
+            assert_eq!(
+                vbe.mode_info.direct_color_attributes,
+                VBEDirectColorAttributes::RESERVED_USABLE
+            );
             assert_eq!(vbe.mode_info.framebuffer_base_ptr, 4244635648);
             assert_eq!(vbe.mode_info.offscreen_memory_offset, 0);
             assert_eq!(vbe.mode_info.offscreen_memory_size, 0);
@@ -764,267 +700,254 @@ mod tests {
         #[repr(C, align(8))]
         struct Bytes([u8; 960]);
         let mut bytes: Bytes = Bytes([
-            192, 3, 0, 0,       // total_size
-            0, 0, 0, 0,         // reserved
-            1, 0, 0, 0,         // boot command tag type
-            9, 0, 0, 0,         // boot command tag size
-            0, 0, 0, 0,         // boot command null + padding
-            0, 0, 0, 0,         // boot command padding
-            2, 0, 0, 0,         // boot loader name tag type
-            26, 0, 0, 0,        // boot loader name tag size
-            71, 82, 85, 66,     // boot loader name
-            32, 50, 46, 48,     // boot loader name
-            50, 126, 98, 101,   // boot loader name
-            116, 97, 51, 45,    // boot loader name
-            53, 0, 0, 0,        // boot loader name null + padding
-            0, 0, 0, 0,         // boot loader name padding
-            10, 0, 0, 0,        // APM tag type
-            28, 0, 0, 0,        // APM tag size
-            2, 1, 0, 240,       // APM version, cseg
-            207, 212, 0, 0,     // APM offset
-            0, 240, 0, 240,     // APM cseg_16, dseg
-            3, 0, 240, 255,     // APM flags, cseg_len
+            192, 3, 0, 0, // total_size
+            0, 0, 0, 0, // reserved
+            1, 0, 0, 0, // boot command tag type
+            9, 0, 0, 0, // boot command tag size
+            0, 0, 0, 0, // boot command null + padding
+            0, 0, 0, 0, // boot command padding
+            2, 0, 0, 0, // boot loader name tag type
+            26, 0, 0, 0, // boot loader name tag size
+            71, 82, 85, 66, // boot loader name
+            32, 50, 46, 48, // boot loader name
+            50, 126, 98, 101, // boot loader name
+            116, 97, 51, 45, // boot loader name
+            53, 0, 0, 0, // boot loader name null + padding
+            0, 0, 0, 0, // boot loader name padding
+            10, 0, 0, 0, // APM tag type
+            28, 0, 0, 0, // APM tag size
+            2, 1, 0, 240, // APM version, cseg
+            207, 212, 0, 0, // APM offset
+            0, 240, 0, 240, // APM cseg_16, dseg
+            3, 0, 240, 255, // APM flags, cseg_len
             240, 255, 240, 255, // APM cseg_16_len, dseg_len
-            0, 0, 0, 0,         // APM padding
-            6, 0, 0, 0,         // memory map tag type
-            160, 0, 0, 0,       // memory map tag size
-            24, 0, 0, 0,        // memory map entry_size
-            0, 0, 0, 0,         // memory map entry_version
-            0, 0, 0, 0,         // memory map entry 0 base_addr
-            0, 0, 0, 0,         // memory map entry 0 base_addr
-            0, 252, 9, 0,       // memory map entry 0 length
-            0, 0, 0, 0,         // memory map entry 0 length
-            1, 0, 0, 0,         // memory map entry 0 type
-            0, 0, 0, 0,         // memory map entry 0 reserved
-            0, 252, 9, 0,       // memory map entry 1 base_addr
-            0, 0, 0, 0,         // memory map entry 1 base_addr
-            0, 4, 0, 0,         // memory map entry 1 length
-            0, 0, 0, 0,         // memory map entry 1 length
-            2, 0, 0, 0,         // memory map entry 1 type
-            0, 0, 0, 0,         // memory map entry 1 reserved
-            0, 0, 15, 0,        // memory map entry 2 base_addr
-            0, 0, 0, 0,         // memory map entry 2 base_addr
-            0, 0, 1, 0,         // memory map entry 2 length
-            0, 0, 0, 0,         // memory map entry 2 length
-            2, 0, 0, 0,         // memory map entry 2 type
-            0, 0, 0, 0,         // memory map entry 2 reserved
-            0, 0, 16, 0,        // memory map entry 3 base_addr
-            0, 0, 0, 0,         // memory map entry 3 base_addr
-            0, 0, 238, 7,       // memory map entry 3 length
-            0, 0, 0, 0,         // memory map entry 3 length
-            1, 0, 0, 0,         // memory map entry 3 type
-            0, 0, 0, 0,         // memory map entry 3 reserved
-            0, 0, 254, 7,       // memory map entry 4 base_addr
-            0, 0, 0, 0,         // memory map entry 4 base_addr
-            0, 0, 2, 0,         // memory map entry 4 length
-            0, 0, 0, 0,         // memory map entry 4 length
-            2, 0, 0, 0,         // memory map entry 4 type
-            0, 0, 0, 0,         // memory map entry 4 reserved
-            0, 0, 252, 255,     // memory map entry 5 base_addr
-            0, 0, 0, 0,         // memory map entry 5 base_addr
-            0, 0, 4, 0,         // memory map entry 5 length
-            0, 0, 0, 0,         // memory map entry 5 length
-            2, 0, 0, 0,         // memory map entry 5 type
-            0, 0, 0, 0,         // memory map entry 5 reserved
-            9, 0, 0, 0,         // elf symbols tag type
-            84, 2, 0, 0,        // elf symbols tag size
-            9, 0, 0, 0,         // elf symbols num
-            64, 0, 0, 0,        // elf symbols entsize
-            8, 0, 0, 0,         // elf symbols shndx
-            0, 0, 0, 0,         // elf symbols entry 0 name
-            0, 0, 0, 0,         // elf symbols entry 0 type
-            0, 0, 0, 0,         // elf symbols entry 0 flags
-            0, 0, 0, 0,         // elf symbols entry 0 flags
-            0, 0, 0, 0,         // elf symbols entry 0 addr
-            0, 0, 0, 0,         // elf symbols entry 0 addr
-            0, 0, 0, 0,         // elf symbols entry 0 offset
-            0, 0, 0, 0,         // elf symbols entry 0 offset
-            0, 0, 0, 0,         // elf symbols entry 0 size
-            0, 0, 0, 0,         // elf symbols entry 0 size
-            0, 0, 0, 0,         // elf symbols entry 0 link
-            0, 0, 0, 0,         // elf symbols entry 0 info
-            0, 0, 0, 0,         // elf symbols entry 0 addralign
-            0, 0, 0, 0,         // elf symbols entry 0 addralign
-            0, 0, 0, 0,         // elf symbols entry 0 entsize
-            0, 0, 0, 0,         // elf symbols entry 0 entsize
-            27, 0, 0, 0,        // elf symbols entry 1 name
-            1, 0, 0, 0,         // elf symbols entry 1 type
-            2, 0, 0, 0,         // elf symbols entry 1 flags
-            0, 0, 0, 0,         // elf symbols entry 1 flags
-            0, 0, 16, 0,        // elf symbols entry 1 addr
-            0, 128, 255, 255,   // elf symbols entry 1 addr
-            0, 16, 0, 0,        // elf symbols entry 1 offset
-            0, 0, 0, 0,         // elf symbols entry 1 offset
-            0, 48, 0, 0,        // elf symbols entry 1 size
-            0, 0, 0, 0,         // elf symbols entry 1 size
-            0, 0, 0, 0,         // elf symbols entry 1 link
-            0, 0, 0, 0,         // elf symbols entry 1 info
-            16, 0, 0, 0,        // elf symbols entry 1 addralign
-            0, 0, 0, 0,         // elf symbols entry 1 addralign
-            0, 0, 0, 0,         // elf symbols entry 1 entsize
-            0, 0, 0, 0,         // elf symbols entry 1 entsize
-            35, 0, 0, 0,        // elf symbols entry 2 name
-            1, 0, 0, 0,         // elf symbols entry 2 type
-            6, 0, 0, 0,         // elf symbols entry 2 flags
-            0, 0, 0, 0,         // elf symbols entry 2 flags
-            0, 48, 16, 0,       // elf symbols entry 2 addr
-            0, 128, 255, 255,   // elf symbols entry 2 addr
-            0, 64, 0, 0,        // elf symbols entry 2 offset
-            0, 0, 0, 0,         // elf symbols entry 2 offset
-            0, 144, 0, 0,       // elf symbols entry 2 size
-            0, 0, 0, 0,         // elf symbols entry 2 size
-            0, 0, 0, 0,         // elf symbols entry 2 link
-            0, 0, 0, 0,         // elf symbols entry 2 info
-            16, 0, 0, 0,        // elf symbols entry 2 addralign
-            0, 0, 0, 0,         // elf symbols entry 2 addralign
-            0, 0, 0, 0,         // elf symbols entry 2 entsize
-            0, 0, 0, 0,         // elf symbols entry 2 entsize
-            41, 0, 0, 0,        // elf symbols entry 3 name
-            1, 0, 0, 0,         // elf symbols entry 3 type
-            3, 0, 0, 0,         // elf symbols entry 3 flags
-            0, 0, 0, 0,         // elf symbols entry 3 flags
-            0, 192, 16, 0,      // elf symbols entry 3 addr
-            0, 128, 255, 255,   // elf symbols entry 3 addr
-            0, 208, 0, 0,       // elf symbols entry 3 offset
-            0, 0, 0, 0,         // elf symbols entry 3 offset
-            0, 32, 0, 0,        // elf symbols entry 3 size
-            0, 0, 0, 0,         // elf symbols entry 3 size
-            0, 0, 0, 0,         // elf symbols entry 3 link
-            0, 0, 0, 0,         // elf symbols entry 3 info
-            8, 0, 0, 0,         // elf symbols entry 3 addralign
-            0, 0, 0, 0,         // elf symbols entry 3 addralign
-            0, 0, 0, 0,         // elf symbols entry 3 entsize
-            0, 0, 0, 0,         // elf symbols entry 3 entsize
-            47, 0, 0, 0,        // elf symbols entry 4 name
-            8, 0, 0, 0,         // elf symbols entry 4 type
-            3, 0, 0, 0,         // elf symbols entry 4 flags
-            0, 0, 0, 0,         // elf symbols entry 4 flags
-            0, 224, 16, 0,      // elf symbols entry 4 addr
-            0, 128, 255, 255,   // elf symbols entry 4 addr
-            0, 240, 0, 0,       // elf symbols entry 4 offset
-            0, 0, 0, 0,         // elf symbols entry 4 offset
-            0, 80, 0, 0,        // elf symbols entry 4 size
-            0, 0, 0, 0,         // elf symbols entry 4 size
-            0, 0, 0, 0,         // elf symbols entry 4 link
-            0, 0, 0, 0,         // elf symbols entry 4 info
-            0, 16, 0, 0,        // elf symbols entry 4 addralign
-            0, 0, 0, 0,         // elf symbols entry 4 addralign
-            0, 0, 0, 0,         // elf symbols entry 4 entsize
-            0, 0, 0, 0,         // elf symbols entry 4 entsize
-            52, 0, 0, 0,        // elf symbols entry 5 name
-            1, 0, 0, 0,         // elf symbols entry 5 type
-            3, 0, 0, 0,         // elf symbols entry 5 flags
-            0, 0, 0, 0,         // elf symbols entry 5 flags
-            0, 48, 17, 0,       // elf symbols entry 5 addr
-            0, 128, 255, 255,   // elf symbols entry 5 addr
-            0, 240, 0, 0,       // elf symbols entry 5 offset
-            0, 0, 0, 0,         // elf symbols entry 5 offset
-            0, 0, 0, 0,         // elf symbols entry 5 size
-            0, 0, 0, 0,         // elf symbols entry 5 size
-            0, 0, 0, 0,         // elf symbols entry 5 link
-            0, 0, 0, 0,         // elf symbols entry 5 info
-            1, 0, 0, 0,         // elf symbols entry 5 addralign
-            0, 0, 0, 0,         // elf symbols entry 5 addralign
-            0, 0, 0, 0,         // elf symbols entry 5 entsize
-            0, 0, 0, 0,         // elf symbols entry 5 entsize
-            1, 0, 0, 0,         // elf symbols entry 6 name
-            2, 0, 0, 0,         // elf symbols entry 6 type
-            0, 0, 0, 0,         // elf symbols entry 6 flags
-            0, 0, 0, 0,         // elf symbols entry 6 flags
-            0, 48, 17, 0,       // elf symbols entry 6 addr
-            0, 0, 0, 0,         // elf symbols entry 6 addr
-            0, 240, 0, 0,       // elf symbols entry 6 offset
-            0, 0, 0, 0,         // elf symbols entry 6 offset
-            224, 43, 0, 0,      // elf symbols entry 6 size
-            0, 0, 0, 0,         // elf symbols entry 6 size
-            7, 0, 0, 0,         // elf symbols entry 6 link
-            102, 1, 0, 0,       // elf symbols entry 6 info
-            8, 0, 0, 0,         // elf symbols entry 6 addralign
-            0, 0, 0, 0,         // elf symbols entry 6 addralign
-            24, 0, 0, 0,        // elf symbols entry 6 entsize
-            0, 0, 0, 0,         // elf symbols entry 6 entsize
-            9, 0, 0, 0,         // elf symbols entry 7 name
-            3, 0, 0, 0,         // elf symbols entry 7 type
-            0, 0, 0, 0,         // elf symbols entry 7 flags
-            0, 0, 0, 0,         // elf symbols entry 7 flags
-            224, 91, 17, 0,     // elf symbols entry 7 addr
-            0, 0, 0, 0,         // elf symbols entry 7 addr
-            224, 27, 1, 0,      // elf symbols entry 7 offset
-            0, 0, 0, 0,         // elf symbols entry 7 offset
-            145, 55, 0, 0,      // elf symbols entry 7 size
-            0, 0, 0, 0,         // elf symbols entry 7 size
-            0, 0, 0, 0,         // elf symbols entry 7 link
-            0, 0, 0, 0,         // elf symbols entry 7 info
-            1, 0, 0, 0,         // elf symbols entry 7 addralign
-            0, 0, 0, 0,         // elf symbols entry 7 addralign
-            0, 0, 0, 0,         // elf symbols entry 7 entsize
-            0, 0, 0, 0,         // elf symbols entry 7 entsize
-            17, 0, 0, 0,        // elf symbols entry 8 name
-            3, 0, 0, 0,         // elf symbols entry 8 type
-            0, 0, 0, 0,         // elf symbols entry 8 flags
-            0, 0, 0, 0,         // elf symbols entry 8 flags
-            113, 147, 17, 0,    // elf symbols entry 8 addr
-            0, 0, 0, 0,         // elf symbols entry 8 addr
-            113, 83, 1, 0,      // elf symbols entry 8 offset
-            0, 0, 0, 0,         // elf symbols entry 8 offset
-            65, 0, 0, 0,        // elf symbols entry 8 size
-            0, 0, 0, 0,         // elf symbols entry 8 size
-            0, 0, 0, 0,         // elf symbols entry 8 link
-            0, 0, 0, 0,         // elf symbols entry 8 info
-            1, 0, 0, 0,         // elf symbols entry 8 addralign
-            0, 0, 0, 0,         // elf symbols entry 8 addralign
-            0, 0, 0, 0,         // elf symbols entry 8 entsize
-            0, 0, 0, 0,         // elf symbols entry 8 entsize
-            0, 0, 0, 0,         // elf symbols padding
-            4, 0, 0, 0,         // basic memory tag type
-            16, 0, 0, 0,        // basic memory tag size
-            127, 2, 0, 0,       // basic memory mem_lower
-            128, 251, 1, 0,     // basic memory mem_upper
-            5, 0, 0, 0,         // BIOS boot device tag type
-            20, 0, 0, 0,        // BIOS boot device tag size
-            224, 0, 0, 0,       // BIOS boot device biosdev
+            0, 0, 0, 0, // APM padding
+            6, 0, 0, 0, // memory map tag type
+            160, 0, 0, 0, // memory map tag size
+            24, 0, 0, 0, // memory map entry_size
+            0, 0, 0, 0, // memory map entry_version
+            0, 0, 0, 0, // memory map entry 0 base_addr
+            0, 0, 0, 0, // memory map entry 0 base_addr
+            0, 252, 9, 0, // memory map entry 0 length
+            0, 0, 0, 0, // memory map entry 0 length
+            1, 0, 0, 0, // memory map entry 0 type
+            0, 0, 0, 0, // memory map entry 0 reserved
+            0, 252, 9, 0, // memory map entry 1 base_addr
+            0, 0, 0, 0, // memory map entry 1 base_addr
+            0, 4, 0, 0, // memory map entry 1 length
+            0, 0, 0, 0, // memory map entry 1 length
+            2, 0, 0, 0, // memory map entry 1 type
+            0, 0, 0, 0, // memory map entry 1 reserved
+            0, 0, 15, 0, // memory map entry 2 base_addr
+            0, 0, 0, 0, // memory map entry 2 base_addr
+            0, 0, 1, 0, // memory map entry 2 length
+            0, 0, 0, 0, // memory map entry 2 length
+            2, 0, 0, 0, // memory map entry 2 type
+            0, 0, 0, 0, // memory map entry 2 reserved
+            0, 0, 16, 0, // memory map entry 3 base_addr
+            0, 0, 0, 0, // memory map entry 3 base_addr
+            0, 0, 238, 7, // memory map entry 3 length
+            0, 0, 0, 0, // memory map entry 3 length
+            1, 0, 0, 0, // memory map entry 3 type
+            0, 0, 0, 0, // memory map entry 3 reserved
+            0, 0, 254, 7, // memory map entry 4 base_addr
+            0, 0, 0, 0, // memory map entry 4 base_addr
+            0, 0, 2, 0, // memory map entry 4 length
+            0, 0, 0, 0, // memory map entry 4 length
+            2, 0, 0, 0, // memory map entry 4 type
+            0, 0, 0, 0, // memory map entry 4 reserved
+            0, 0, 252, 255, // memory map entry 5 base_addr
+            0, 0, 0, 0, // memory map entry 5 base_addr
+            0, 0, 4, 0, // memory map entry 5 length
+            0, 0, 0, 0, // memory map entry 5 length
+            2, 0, 0, 0, // memory map entry 5 type
+            0, 0, 0, 0, // memory map entry 5 reserved
+            9, 0, 0, 0, // elf symbols tag type
+            84, 2, 0, 0, // elf symbols tag size
+            9, 0, 0, 0, // elf symbols num
+            64, 0, 0, 0, // elf symbols entsize
+            8, 0, 0, 0, // elf symbols shndx
+            0, 0, 0, 0, // elf symbols entry 0 name
+            0, 0, 0, 0, // elf symbols entry 0 type
+            0, 0, 0, 0, // elf symbols entry 0 flags
+            0, 0, 0, 0, // elf symbols entry 0 flags
+            0, 0, 0, 0, // elf symbols entry 0 addr
+            0, 0, 0, 0, // elf symbols entry 0 addr
+            0, 0, 0, 0, // elf symbols entry 0 offset
+            0, 0, 0, 0, // elf symbols entry 0 offset
+            0, 0, 0, 0, // elf symbols entry 0 size
+            0, 0, 0, 0, // elf symbols entry 0 size
+            0, 0, 0, 0, // elf symbols entry 0 link
+            0, 0, 0, 0, // elf symbols entry 0 info
+            0, 0, 0, 0, // elf symbols entry 0 addralign
+            0, 0, 0, 0, // elf symbols entry 0 addralign
+            0, 0, 0, 0, // elf symbols entry 0 entsize
+            0, 0, 0, 0, // elf symbols entry 0 entsize
+            27, 0, 0, 0, // elf symbols entry 1 name
+            1, 0, 0, 0, // elf symbols entry 1 type
+            2, 0, 0, 0, // elf symbols entry 1 flags
+            0, 0, 0, 0, // elf symbols entry 1 flags
+            0, 0, 16, 0, // elf symbols entry 1 addr
+            0, 128, 255, 255, // elf symbols entry 1 addr
+            0, 16, 0, 0, // elf symbols entry 1 offset
+            0, 0, 0, 0, // elf symbols entry 1 offset
+            0, 48, 0, 0, // elf symbols entry 1 size
+            0, 0, 0, 0, // elf symbols entry 1 size
+            0, 0, 0, 0, // elf symbols entry 1 link
+            0, 0, 0, 0, // elf symbols entry 1 info
+            16, 0, 0, 0, // elf symbols entry 1 addralign
+            0, 0, 0, 0, // elf symbols entry 1 addralign
+            0, 0, 0, 0, // elf symbols entry 1 entsize
+            0, 0, 0, 0, // elf symbols entry 1 entsize
+            35, 0, 0, 0, // elf symbols entry 2 name
+            1, 0, 0, 0, // elf symbols entry 2 type
+            6, 0, 0, 0, // elf symbols entry 2 flags
+            0, 0, 0, 0, // elf symbols entry 2 flags
+            0, 48, 16, 0, // elf symbols entry 2 addr
+            0, 128, 255, 255, // elf symbols entry 2 addr
+            0, 64, 0, 0, // elf symbols entry 2 offset
+            0, 0, 0, 0, // elf symbols entry 2 offset
+            0, 144, 0, 0, // elf symbols entry 2 size
+            0, 0, 0, 0, // elf symbols entry 2 size
+            0, 0, 0, 0, // elf symbols entry 2 link
+            0, 0, 0, 0, // elf symbols entry 2 info
+            16, 0, 0, 0, // elf symbols entry 2 addralign
+            0, 0, 0, 0, // elf symbols entry 2 addralign
+            0, 0, 0, 0, // elf symbols entry 2 entsize
+            0, 0, 0, 0, // elf symbols entry 2 entsize
+            41, 0, 0, 0, // elf symbols entry 3 name
+            1, 0, 0, 0, // elf symbols entry 3 type
+            3, 0, 0, 0, // elf symbols entry 3 flags
+            0, 0, 0, 0, // elf symbols entry 3 flags
+            0, 192, 16, 0, // elf symbols entry 3 addr
+            0, 128, 255, 255, // elf symbols entry 3 addr
+            0, 208, 0, 0, // elf symbols entry 3 offset
+            0, 0, 0, 0, // elf symbols entry 3 offset
+            0, 32, 0, 0, // elf symbols entry 3 size
+            0, 0, 0, 0, // elf symbols entry 3 size
+            0, 0, 0, 0, // elf symbols entry 3 link
+            0, 0, 0, 0, // elf symbols entry 3 info
+            8, 0, 0, 0, // elf symbols entry 3 addralign
+            0, 0, 0, 0, // elf symbols entry 3 addralign
+            0, 0, 0, 0, // elf symbols entry 3 entsize
+            0, 0, 0, 0, // elf symbols entry 3 entsize
+            47, 0, 0, 0, // elf symbols entry 4 name
+            8, 0, 0, 0, // elf symbols entry 4 type
+            3, 0, 0, 0, // elf symbols entry 4 flags
+            0, 0, 0, 0, // elf symbols entry 4 flags
+            0, 224, 16, 0, // elf symbols entry 4 addr
+            0, 128, 255, 255, // elf symbols entry 4 addr
+            0, 240, 0, 0, // elf symbols entry 4 offset
+            0, 0, 0, 0, // elf symbols entry 4 offset
+            0, 80, 0, 0, // elf symbols entry 4 size
+            0, 0, 0, 0, // elf symbols entry 4 size
+            0, 0, 0, 0, // elf symbols entry 4 link
+            0, 0, 0, 0, // elf symbols entry 4 info
+            0, 16, 0, 0, // elf symbols entry 4 addralign
+            0, 0, 0, 0, // elf symbols entry 4 addralign
+            0, 0, 0, 0, // elf symbols entry 4 entsize
+            0, 0, 0, 0, // elf symbols entry 4 entsize
+            52, 0, 0, 0, // elf symbols entry 5 name
+            1, 0, 0, 0, // elf symbols entry 5 type
+            3, 0, 0, 0, // elf symbols entry 5 flags
+            0, 0, 0, 0, // elf symbols entry 5 flags
+            0, 48, 17, 0, // elf symbols entry 5 addr
+            0, 128, 255, 255, // elf symbols entry 5 addr
+            0, 240, 0, 0, // elf symbols entry 5 offset
+            0, 0, 0, 0, // elf symbols entry 5 offset
+            0, 0, 0, 0, // elf symbols entry 5 size
+            0, 0, 0, 0, // elf symbols entry 5 size
+            0, 0, 0, 0, // elf symbols entry 5 link
+            0, 0, 0, 0, // elf symbols entry 5 info
+            1, 0, 0, 0, // elf symbols entry 5 addralign
+            0, 0, 0, 0, // elf symbols entry 5 addralign
+            0, 0, 0, 0, // elf symbols entry 5 entsize
+            0, 0, 0, 0, // elf symbols entry 5 entsize
+            1, 0, 0, 0, // elf symbols entry 6 name
+            2, 0, 0, 0, // elf symbols entry 6 type
+            0, 0, 0, 0, // elf symbols entry 6 flags
+            0, 0, 0, 0, // elf symbols entry 6 flags
+            0, 48, 17, 0, // elf symbols entry 6 addr
+            0, 0, 0, 0, // elf symbols entry 6 addr
+            0, 240, 0, 0, // elf symbols entry 6 offset
+            0, 0, 0, 0, // elf symbols entry 6 offset
+            224, 43, 0, 0, // elf symbols entry 6 size
+            0, 0, 0, 0, // elf symbols entry 6 size
+            7, 0, 0, 0, // elf symbols entry 6 link
+            102, 1, 0, 0, // elf symbols entry 6 info
+            8, 0, 0, 0, // elf symbols entry 6 addralign
+            0, 0, 0, 0, // elf symbols entry 6 addralign
+            24, 0, 0, 0, // elf symbols entry 6 entsize
+            0, 0, 0, 0, // elf symbols entry 6 entsize
+            9, 0, 0, 0, // elf symbols entry 7 name
+            3, 0, 0, 0, // elf symbols entry 7 type
+            0, 0, 0, 0, // elf symbols entry 7 flags
+            0, 0, 0, 0, // elf symbols entry 7 flags
+            224, 91, 17, 0, // elf symbols entry 7 addr
+            0, 0, 0, 0, // elf symbols entry 7 addr
+            224, 27, 1, 0, // elf symbols entry 7 offset
+            0, 0, 0, 0, // elf symbols entry 7 offset
+            145, 55, 0, 0, // elf symbols entry 7 size
+            0, 0, 0, 0, // elf symbols entry 7 size
+            0, 0, 0, 0, // elf symbols entry 7 link
+            0, 0, 0, 0, // elf symbols entry 7 info
+            1, 0, 0, 0, // elf symbols entry 7 addralign
+            0, 0, 0, 0, // elf symbols entry 7 addralign
+            0, 0, 0, 0, // elf symbols entry 7 entsize
+            0, 0, 0, 0, // elf symbols entry 7 entsize
+            17, 0, 0, 0, // elf symbols entry 8 name
+            3, 0, 0, 0, // elf symbols entry 8 type
+            0, 0, 0, 0, // elf symbols entry 8 flags
+            0, 0, 0, 0, // elf symbols entry 8 flags
+            113, 147, 17, 0, // elf symbols entry 8 addr
+            0, 0, 0, 0, // elf symbols entry 8 addr
+            113, 83, 1, 0, // elf symbols entry 8 offset
+            0, 0, 0, 0, // elf symbols entry 8 offset
+            65, 0, 0, 0, // elf symbols entry 8 size
+            0, 0, 0, 0, // elf symbols entry 8 size
+            0, 0, 0, 0, // elf symbols entry 8 link
+            0, 0, 0, 0, // elf symbols entry 8 info
+            1, 0, 0, 0, // elf symbols entry 8 addralign
+            0, 0, 0, 0, // elf symbols entry 8 addralign
+            0, 0, 0, 0, // elf symbols entry 8 entsize
+            0, 0, 0, 0, // elf symbols entry 8 entsize
+            0, 0, 0, 0, // elf symbols padding
+            4, 0, 0, 0, // basic memory tag type
+            16, 0, 0, 0, // basic memory tag size
+            127, 2, 0, 0, // basic memory mem_lower
+            128, 251, 1, 0, // basic memory mem_upper
+            5, 0, 0, 0, // BIOS boot device tag type
+            20, 0, 0, 0, // BIOS boot device tag size
+            224, 0, 0, 0, // BIOS boot device biosdev
             255, 255, 255, 255, // BIOS boot device partition
             255, 255, 255, 255, // BIOS boot device subpartition
-            0, 0, 0, 0,         // BIOS boot device padding
-            8, 0, 0, 0,         // framebuffer info tag type
-            32, 0, 0, 0,        // framebuffer info tag size
-            0, 128, 11, 0,      // framebuffer info framebuffer_addr
-            0, 0, 0, 0,         // framebuffer info framebuffer_addr
-            160, 0, 0, 0,       // framebuffer info framebuffer_pitch
-            80, 0, 0, 0,        // framebuffer info framebuffer_width
-            25, 0, 0, 0,        // framebuffer info framebuffer_height
-            16, 2, 0, 0,        // framebuffer info framebuffer_[bpp,type], reserved, color_info
-            14, 0, 0, 0,        // ACPI old tag type
-            28, 0, 0, 0,        // ACPI old tag size
-            82, 83, 68, 32,     // ACPI old
-            80, 84, 82, 32,     // ACPI old
-            89, 66, 79, 67,     // ACPI old
-            72, 83, 32, 0,      // ACPI old
-            220, 24, 254, 7,    // ACPI old
-            0, 0, 0, 0,         // ACPI old padding
-            0, 0, 0, 0,         // end tag type
-            8, 0, 0, 0,         // end tag size
+            0, 0, 0, 0, // BIOS boot device padding
+            8, 0, 0, 0, // framebuffer info tag type
+            32, 0, 0, 0, // framebuffer info tag size
+            0, 128, 11, 0, // framebuffer info framebuffer_addr
+            0, 0, 0, 0, // framebuffer info framebuffer_addr
+            160, 0, 0, 0, // framebuffer info framebuffer_pitch
+            80, 0, 0, 0, // framebuffer info framebuffer_width
+            25, 0, 0, 0, // framebuffer info framebuffer_height
+            16, 2, 0, 0, // framebuffer info framebuffer_[bpp,type], reserved, color_info
+            14, 0, 0, 0, // ACPI old tag type
+            28, 0, 0, 0, // ACPI old tag size
+            82, 83, 68, 32, // ACPI old
+            80, 84, 82, 32, // ACPI old
+            89, 66, 79, 67, // ACPI old
+            72, 83, 32, 0, // ACPI old
+            220, 24, 254, 7, // ACPI old
+            0, 0, 0, 0, // ACPI old padding
+            0, 0, 0, 0, // end tag type
+            8, 0, 0, 0, // end tag size
         ]);
         #[repr(C, align(8))]
         struct StringBytes([u8; 65]);
         let string_bytes: StringBytes = StringBytes([
-            0, 46, 115, 121,
-            109, 116, 97, 98,
-            0, 46, 115, 116,
-            114, 116, 97, 98,
-            0, 46, 115, 104,
-            115, 116, 114, 116,
-            97, 98, 0, 46,
-            114, 111, 100, 97,
-            116, 97, 0, 46,
-            116, 101, 120, 116,
-            0, 46, 100, 97,
-            116, 97, 0, 46,
-            98, 115, 115, 0,
-            46, 100, 97, 116,
-            97, 46, 114, 101,
-            108, 46, 114, 111,
-            0,
+            0, 46, 115, 121, 109, 116, 97, 98, 0, 46, 115, 116, 114, 116, 97, 98, 0, 46, 115, 104,
+            115, 116, 114, 116, 97, 98, 0, 46, 114, 111, 100, 97, 116, 97, 0, 46, 116, 101, 120,
+            116, 0, 46, 100, 97, 116, 97, 0, 46, 98, 115, 115, 0, 46, 100, 97, 116, 97, 46, 114,
+            101, 108, 46, 114, 111, 0,
         ]);
         let string_addr = string_bytes.0.as_ptr() as u64;
         for i in 0..8 {
@@ -1082,28 +1005,40 @@ mod tests {
         assert_eq!(0xFFFF_8000_0010_3000, s2.start_address());
         assert_eq!(0xFFFF_8000_0010_C000, s2.end_address());
         assert_eq!(0x0000_0000_0000_9000, s2.size());
-        assert_eq!(ElfSectionFlags::EXECUTABLE | ElfSectionFlags::ALLOCATED, s2.flags());
+        assert_eq!(
+            ElfSectionFlags::EXECUTABLE | ElfSectionFlags::ALLOCATED,
+            s2.flags()
+        );
         assert_eq!(ElfSectionType::ProgramSection, s2.section_type());
         let s3 = s.next().unwrap();
         assert_eq!(".data", s3.name());
         assert_eq!(0xFFFF_8000_0010_C000, s3.start_address());
         assert_eq!(0xFFFF_8000_0010_E000, s3.end_address());
         assert_eq!(0x0000_0000_0000_2000, s3.size());
-        assert_eq!(ElfSectionFlags::ALLOCATED | ElfSectionFlags::WRITABLE, s3.flags());
+        assert_eq!(
+            ElfSectionFlags::ALLOCATED | ElfSectionFlags::WRITABLE,
+            s3.flags()
+        );
         assert_eq!(ElfSectionType::ProgramSection, s3.section_type());
         let s4 = s.next().unwrap();
         assert_eq!(".bss", s4.name());
         assert_eq!(0xFFFF_8000_0010_E000, s4.start_address());
         assert_eq!(0xFFFF_8000_0011_3000, s4.end_address());
         assert_eq!(0x0000_0000_0000_5000, s4.size());
-        assert_eq!(ElfSectionFlags::ALLOCATED | ElfSectionFlags::WRITABLE, s4.flags());
+        assert_eq!(
+            ElfSectionFlags::ALLOCATED | ElfSectionFlags::WRITABLE,
+            s4.flags()
+        );
         assert_eq!(ElfSectionType::Uninitialized, s4.section_type());
         let s5 = s.next().unwrap();
         assert_eq!(".data.rel.ro", s5.name());
         assert_eq!(0xFFFF_8000_0011_3000, s5.start_address());
         assert_eq!(0xFFFF_8000_0011_3000, s5.end_address());
         assert_eq!(0x0000_0000_0000_0000, s5.size());
-        assert_eq!(ElfSectionFlags::ALLOCATED | ElfSectionFlags::WRITABLE, s5.flags());
+        assert_eq!(
+            ElfSectionFlags::ALLOCATED | ElfSectionFlags::WRITABLE,
+            s5.flags()
+        );
         assert_eq!(ElfSectionType::ProgramSection, s5.section_type());
         let s6 = s.next().unwrap();
         assert_eq!(".symtab", s6.name());
@@ -1149,7 +1084,10 @@ mod tests {
         assert_eq!(0x7FE18DC, rsdp_old.rsdt_address());
 
         assert!(bi.module_tags().next().is_none());
-        assert_eq!("GRUB 2.02~beta3-5", bi.boot_loader_name_tag().unwrap().name());
+        assert_eq!(
+            "GRUB 2.02~beta3-5",
+            bi.boot_loader_name_tag().unwrap().name()
+        );
         assert_eq!("", bi.command_line_tag().unwrap().command_line());
 
         // Test the Framebuffer tag
@@ -1167,56 +1105,53 @@ mod tests {
         #[repr(C, align(8))]
         struct Bytes([u8; 168]);
         let mut bytes: Bytes = Bytes([
-            168, 0, 0, 0,       // total_size
-            0, 0, 0, 0,         // reserved
-            9, 0, 0, 0,         // elf symbols tag type
-            20, 2, 0, 0,        // elf symbols tag size
-            2, 0, 0, 0,         // elf symbols num
-            64, 0, 0, 0,        // elf symbols entsize
-            1, 0, 0, 0,         // elf symbols shndx
-            0, 0, 0, 0,         // elf symbols entry 0 name
-            0, 0, 0, 0,         // elf symbols entry 0 type
-            0, 0, 0, 0,         // elf symbols entry 0 flags
-            0, 0, 0, 0,         // elf symbols entry 0 flags
-            0, 0, 0, 0,         // elf symbols entry 0 addr
-            0, 0, 0, 0,         // elf symbols entry 0 addr
-            0, 0, 0, 0,         // elf symbols entry 0 offset
-            0, 0, 0, 0,         // elf symbols entry 0 offset
-            0, 0, 0, 0,         // elf symbols entry 0 size
-            0, 0, 0, 0,         // elf symbols entry 0 size
-            0, 0, 0, 0,         // elf symbols entry 0 link
-            0, 0, 0, 0,         // elf symbols entry 0 info
-            0, 0, 0, 0,         // elf symbols entry 0 addralign
-            0, 0, 0, 0,         // elf symbols entry 0 addralign
-            0, 0, 0, 0,         // elf symbols entry 0 entsize
-            0, 0, 0, 0,         // elf symbols entry 0 entsize
-            1, 0, 0, 0,         // elf symbols entry 1 name
-            3, 0, 0, 0,         // elf symbols entry 1 type
-            0, 0, 0, 0,         // elf symbols entry 1 flags
-            0, 0, 0, 0,         // elf symbols entry 1 flags
+            168, 0, 0, 0, // total_size
+            0, 0, 0, 0, // reserved
+            9, 0, 0, 0, // elf symbols tag type
+            20, 2, 0, 0, // elf symbols tag size
+            2, 0, 0, 0, // elf symbols num
+            64, 0, 0, 0, // elf symbols entsize
+            1, 0, 0, 0, // elf symbols shndx
+            0, 0, 0, 0, // elf symbols entry 0 name
+            0, 0, 0, 0, // elf symbols entry 0 type
+            0, 0, 0, 0, // elf symbols entry 0 flags
+            0, 0, 0, 0, // elf symbols entry 0 flags
+            0, 0, 0, 0, // elf symbols entry 0 addr
+            0, 0, 0, 0, // elf symbols entry 0 addr
+            0, 0, 0, 0, // elf symbols entry 0 offset
+            0, 0, 0, 0, // elf symbols entry 0 offset
+            0, 0, 0, 0, // elf symbols entry 0 size
+            0, 0, 0, 0, // elf symbols entry 0 size
+            0, 0, 0, 0, // elf symbols entry 0 link
+            0, 0, 0, 0, // elf symbols entry 0 info
+            0, 0, 0, 0, // elf symbols entry 0 addralign
+            0, 0, 0, 0, // elf symbols entry 0 addralign
+            0, 0, 0, 0, // elf symbols entry 0 entsize
+            0, 0, 0, 0, // elf symbols entry 0 entsize
+            1, 0, 0, 0, // elf symbols entry 1 name
+            3, 0, 0, 0, // elf symbols entry 1 type
+            0, 0, 0, 0, // elf symbols entry 1 flags
+            0, 0, 0, 0, // elf symbols entry 1 flags
             255, 255, 255, 255, // elf symbols entry 1 addr
             255, 255, 255, 255, // elf symbols entry 1 addr
-            113, 83, 1, 0,      // elf symbols entry 1 offset
-            0, 0, 0, 0,         // elf symbols entry 1 offset
-            11, 0, 0, 0,        // elf symbols entry 1 size
-            0, 0, 0, 0,         // elf symbols entry 1 size
-            0, 0, 0, 0,         // elf symbols entry 1 link
-            0, 0, 0, 0,         // elf symbols entry 1 info
-            1, 0, 0, 0,         // elf symbols entry 1 addralign
-            0, 0, 0, 0,         // elf symbols entry 1 addralign
-            0, 0, 0, 0,         // elf symbols entry 1 entsize
-            0, 0, 0, 0,         // elf symbols entry 1 entsize
-            0, 0, 0, 0,         // elf symbols padding
-            0, 0, 0, 0,         // end tag type
-            8, 0, 0, 0,         // end tag size
+            113, 83, 1, 0, // elf symbols entry 1 offset
+            0, 0, 0, 0, // elf symbols entry 1 offset
+            11, 0, 0, 0, // elf symbols entry 1 size
+            0, 0, 0, 0, // elf symbols entry 1 size
+            0, 0, 0, 0, // elf symbols entry 1 link
+            0, 0, 0, 0, // elf symbols entry 1 info
+            1, 0, 0, 0, // elf symbols entry 1 addralign
+            0, 0, 0, 0, // elf symbols entry 1 addralign
+            0, 0, 0, 0, // elf symbols entry 1 entsize
+            0, 0, 0, 0, // elf symbols entry 1 entsize
+            0, 0, 0, 0, // elf symbols padding
+            0, 0, 0, 0, // end tag type
+            8, 0, 0, 0, // end tag size
         ]);
         #[repr(C, align(8))]
         struct StringBytes([u8; 11]);
-        let string_bytes: StringBytes = StringBytes([
-            0, 46, 115, 104,
-            115, 116, 114, 116,
-            97, 98, 0,
-        ]);
+        let string_bytes: StringBytes =
+            StringBytes([0, 46, 115, 104, 115, 116, 114, 116, 97, 98, 0]);
         let string_addr = string_bytes.0.as_ptr() as u64;
         for i in 0..8 {
             let offset = 108;

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -8,8 +8,8 @@ use core::marker::PhantomData;
 /// overwrite these regions.
 ///
 /// This tag may not be provided by some boot loaders on EFI platforms if EFI
-/// boot services are enabled and available for the loaded image
-/// (EFI boot services not terminated tag exists in Multiboot2 information structure).   
+/// boot services are enabled and available for the loaded image (The EFI boot
+/// services tag may exist in the Multiboot2 boot information structure).
 #[derive(Debug)]
 #[repr(C)]
 pub struct MemoryMapTag {
@@ -91,7 +91,7 @@ pub enum MemoryAreaType {
     Defective,
 }
 
-/// An area over Available memory areas.
+/// An iterator over Available memory areas.
 #[derive(Clone, Debug)]
 pub struct MemoryAreaIter<'a> {
     current_area: u64,

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -1,5 +1,15 @@
 use core::marker::PhantomData;
 
+/// This Tag provides an initial host memory map.
+///
+/// The map provided is guaranteed to list all standard RAM that should be
+/// available for normal use. This type however includes the regions occupied
+/// by kernel, mbi, segments and modules. Kernel must take care not to
+/// overwrite these regions.
+///
+/// This tag may not be provided by some boot loaders on EFI platforms if EFI
+/// boot services are enabled and available for the loaded image
+/// (EFI boot services not terminated tag exists in Multiboot2 information structure).   
 #[derive(Debug)]
 #[repr(C)]
 pub struct MemoryMapTag {
@@ -11,6 +21,7 @@ pub struct MemoryMapTag {
 }
 
 impl MemoryMapTag {
+    /// Return an iterator over all AVAILABLE marked memory areas.
     pub fn memory_areas(&self) -> MemoryAreaIter {
         let self_ptr = self as *const MemoryMapTag;
         let start_area = (&self.first_area) as *const MemoryArea;
@@ -23,6 +34,7 @@ impl MemoryMapTag {
     }
 }
 
+/// A memory area entry descriptor.
 #[derive(Debug)]
 #[repr(C)]
 pub struct MemoryArea {
@@ -33,18 +45,22 @@ pub struct MemoryArea {
 }
 
 impl MemoryArea {
+    /// The start address of the memory region.
     pub fn start_address(&self) -> u64 {
         self.base_addr
     }
 
+    /// The end address of the memory region.
     pub fn end_address(&self) -> u64 {
         (self.base_addr + self.length)
     }
 
+    /// The size, in bytes, of the memory region.
     pub fn size(&self) -> u64 {
         self.length
     }
 
+    /// The type of the memory region.
     pub fn typ(&self) -> MemoryAreaType {
         match self.typ {
             1 => MemoryAreaType::Available,
@@ -56,15 +72,26 @@ impl MemoryArea {
     }
 }
 
+/// An enum of possible reported region types.
 #[derive(Debug, PartialEq, Eq)]
 pub enum MemoryAreaType {
+    /// A reserved area that must not be used.
     Reserved,
+
+    /// Available memory free to be used by the OS.
     Available,
+
+    /// Usable memory holding ACPI information.
     AcpiAvailable,
+
+    /// Reserved memory which needs to be preserved on hibernation.
     ReservedHibernate,
+
+    /// Memory which is occupied by defective RAM modules.
     Defective,
 }
 
+/// An area over Available memory areas.
 #[derive(Clone, Debug)]
 pub struct MemoryAreaIter<'a> {
     current_area: u64,

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,5 +1,7 @@
 use header::{Tag, TagIter};
 
+/// This tag indicates to the kernel what boot module was loaded along with
+/// the kernel image, and where it can be found. 
 #[derive(Clone, Copy, Debug)]
 #[repr(C, packed)]
 pub struct ModuleTag {
@@ -14,6 +16,7 @@ impl ModuleTag {
     // The multiboot specification defines the module str
     // as valid utf-8, therefore this function produces
     // defined behavior
+    /// Get the name of the module.
     pub fn name(&self) -> &str {
         use core::{mem,str,slice};
         let strlen = self.size as usize - mem::size_of::<ModuleTag>();
@@ -23,10 +26,12 @@ impl ModuleTag {
         }
     }
 
+    /// Start address of the module.
     pub fn start_address(&self) -> u32 {
         self.mod_start
     }
 
+    /// End address of the module
     pub fn end_address(&self) -> u32 {
         self.mod_end
     }
@@ -36,6 +41,7 @@ pub fn module_iter(iter: TagIter) -> ModuleIter {
     ModuleIter { iter: iter }
 }
 
+/// An iterator over all module tags.
 #[derive(Clone, Debug)]
 pub struct ModuleIter<'a> {
     iter: TagIter<'a>,

--- a/src/rsdp.rs
+++ b/src/rsdp.rs
@@ -24,7 +24,7 @@ pub struct RsdpV1Tag {
 impl RsdpV1Tag {
     /// The "RSD PTR " marker singature.
     ///
-    /// This is originally a 8-byte C string (not null terminated!) must contain "RSD PTR ".
+    /// This is originally a 8-byte C string (not null terminated!) that must contain "RSD PTR "
     pub fn signature<'a>(&'a self) -> Option<&'a str> {
         str::from_utf8(&self.signature).ok()
     }
@@ -46,7 +46,7 @@ impl RsdpV1Tag {
         self.revision
     }
 
-    /// 32-bit physical (I repeat: physical) address of the RSDT table.
+    /// The physical (I repeat: physical) address of the RSDT table.
     pub fn rsdt_address(&self) -> usize {
         self.rsdt_address as usize
     }
@@ -72,7 +72,7 @@ pub struct RsdpV2Tag {
 impl RsdpV2Tag {
     /// The "RSD PTR " marker singature.
     ///
-    /// This is originally a 8-byte C string (not null terminated!) must contain "RSD PTR ".
+    /// This is originally a 8-byte C string (not null terminated!) that must contain "RSD PTR ".
     pub fn signature<'a>(&'a self) -> Option<&'a str> {
         str::from_utf8(&self.signature).ok()
     }

--- a/src/rsdp.rs
+++ b/src/rsdp.rs
@@ -8,6 +8,7 @@
 
 use core::str;
 
+/// This tag contains a copy of RSDP as defined per ACPI 1.0 specification. 
 #[derive(Clone, Copy, Debug)]
 #[repr(C, packed)]
 pub struct RsdpV1Tag {
@@ -21,28 +22,37 @@ pub struct RsdpV1Tag {
 }
 
 impl RsdpV1Tag {
+    /// The "RSD PTR " marker singature.
+    ///
+    /// This is originally a 8-byte C string (not null terminated!) must contain "RSD PTR ".
     pub fn signature<'a>(&'a self) -> Option<&'a str> {
         str::from_utf8(&self.signature).ok()
     }
 
+    /// The value to add to all the other bytes (of the Version 1.0 table) to calculate the Checksum of the table.
+    ///
+    /// If this value added to all the others and casted to byte isn't equal to 0, the table must be ignored. 
     pub fn checksum(&self) -> u8 {
         self.checksum
     }
 
+    /// An OEM-supplied string that identifies the OEM. 
     pub fn oem_id<'a>(&'a self) -> Option<&'a str> {
         str::from_utf8(&self.oem_id).ok()
     }
 
+    /// The revision of the ACPI.
     pub fn revision(&self) -> u8 {
         self.revision
     }
 
-    /// Get the physical address of the RSDT.
+    /// 32-bit physical (I repeat: physical) address of the RSDT table.
     pub fn rsdt_address(&self) -> usize {
         self.rsdt_address as usize
     }
 }
 
+/// This tag contains a copy of RSDP as defined per ACPI 2.0 or later specification. 
 #[derive(Clone, Copy, Debug)]
 #[repr(C, packed)]
 pub struct RsdpV2Tag {
@@ -60,27 +70,38 @@ pub struct RsdpV2Tag {
 }
 
 impl RsdpV2Tag {
+    /// The "RSD PTR " marker singature.
+    ///
+    /// This is originally a 8-byte C string (not null terminated!) must contain "RSD PTR ".
     pub fn signature<'a>(&'a self) -> Option<&'a str> {
         str::from_utf8(&self.signature).ok()
     }
 
+    /// The value to add to all the other bytes (of the Version 1.0 table) to calculate the Checksum of the table.
+    ///
+    /// If this value added to all the others and casted to byte isn't equal to 0, the table must be ignored. 
     pub fn checksum(&self) -> u8 {
         self.checksum
     }
 
+    /// An OEM-supplied string that identifies the OEM. 
     pub fn oem_id<'a>(&'a self) -> Option<&'a str> {
         str::from_utf8(&self.oem_id).ok()
     }
 
+    /// The revision of the ACPI.
     pub fn revision(&self) -> u8 {
         self.revision
     }
 
-    /// Get the physical address of the XSDT. On x86, this is truncated from 64-bit to 32-bit.
+    /// Physical address of the XSDT table.
+    ///
+    /// On x86, this is truncated from 64-bit to 32-bit.
     pub fn xsdt_address(&self) -> usize {
         self.xsdt_address as usize
     }
 
+    /// This field is used to calculate the checksum of the entire table, including both checksum fields. 
     pub fn ext_checksum(&self) -> u8 {
         self.ext_checksum
     }

--- a/src/vbe_info.rs
+++ b/src/vbe_info.rs
@@ -181,10 +181,18 @@ pub struct VBEModeInfo {
     /// Physical address for flat memory frame buffer
     pub framebuffer_base_ptr: u32,
 
-    /// This should be a reserved field???
+    /// A pointer to the start of off screen memory.
+    ///
+    /// # Deprecated
+    ///
+    /// In VBE3.0 and above these fields are reserved and unused.
     pub offscreen_memory_offset: u32,
 
-    /// This should be a reserved field???
+    /// The amount of off screen memory in 1k units.
+    ///
+    /// # Deprecated
+    ///
+    /// In VBE3.0 and above these fields are reserved and unused.
     pub offscreen_memory_size: u16,
 
     /// Remainder of mode info block

--- a/src/vbe_info.rs
+++ b/src/vbe_info.rs
@@ -12,12 +12,21 @@ pub struct VBEInfoTag {
     pub mode: u16,
 
     /// Contain the segment of the table of a protected mode interface defined in VBE 2.0+.
+    ///
+    /// If the information for a protected mode interface is not available
+    /// this field is set to zero.
     pub interface_segment: u16,
 
     /// Contain the segment offset of the table of a protected mode interface defined in VBE 2.0+.
+    ///
+    /// If the information for a protected mode interface is not available
+    /// this field is set to zero.
     pub interface_offset: u16,
 
     /// Contain the segment length of the table of a protected mode interface defined in VBE 2.0+.
+    ///
+    /// If the information for a protected mode interface is not available
+    /// this field is set to zero.
     pub interface_length: u16,
 
     /// Contains VBE controller information returned by the VBE Function `00h`.
@@ -234,13 +243,15 @@ bitflags! {
     /// The Capabilities field indicates the support of specific features in the graphics environment.
     pub struct VBECapabilities: u32 {
         /// Can the DAC be switched between 6 and 8 bit modes.
-        const SWITCHABLE_DAC = 0x1;     // The DAC can be switched between 6 and 8-bit modes.
+        const SWITCHABLE_DAC = 0x1;
 
         /// Is the controller VGA compatible.
-        const NOT_VGA_COMPATIBLE = 0x2; // The controller can be switched into VGA modes.
+        const NOT_VGA_COMPATIBLE = 0x2;
 
-        /// The operating behaviour of the RAMDAC
-        const RAMDAC_FIX = 0x4;         // When writing lots of information to the palette, the blank bit should be used.
+        /// The operating behaviour of the RAMDAC.
+        ///
+        /// When writing lots of information to the RAMDAC, use the blank bit in Function `09h`.
+        const RAMDAC_FIX = 0x4;
     }
 }
 
@@ -248,10 +259,10 @@ bitflags! {
     /// A Mode attributes bitfield.
     pub struct VBEModeAttributes: u16 {
         /// Mode supported by hardware configuration.
-        const SUPPORTED = 0x1;           // This mode is supported by the hardware.
+        const SUPPORTED = 0x1;
 
         /// TTY Output functions supported by BIOS
-        const TTY_SUPPORTED = 0x4;       // TTY output is supported.
+        const TTY_SUPPORTED = 0x4;
 
         /// Color support.
         const COLOR = 0x8;
@@ -267,7 +278,7 @@ bitflags! {
         /// If this is set, the window A and B fields of VBEModeInfo are invalid. 
         const NO_VGA_WINDOW = 0x40;
 
-        /// Linear framebugger availability.
+        /// Linear framebuffer availability.
         ///
         /// Set if a linear framebuffer is available for this mode.
         const LINEAR_FRAMEBUFFER = 0x80;
@@ -296,15 +307,15 @@ bitflags! {
     /// Bit D0 specifies whether the color ramp of the DAC is fixed or
     /// programmable. If the color ramp is fixed, then it can not be changed.
     /// If the color ramp is programmable, it is assumed that the red, green,
-    /// and blue lookup tables can be loaded by using VBE Function 09h
+    /// and blue lookup tables can be loaded by using VBE Function `09h`
     /// (it is assumed all color ramp data is 8 bits per primary).
     /// Bit D1 specifies whether the bits in the Rsvd field of the direct color
     /// pixel can be used by the application or are reserved, and thus unusable.
     pub struct VBEDirectColorAttributes: u8 {
-        /// Color ramp is fixed/programmable
+        /// Color ramp is fixed when cleared and programmable when set.
         const PROGRAMMABLE = 0x1;
 
-        /// Bits in Rsvd field are usable/reserved
+        /// Bits in Rsvd field when cleared are reserved and usable when set.
         const RESERVED_USABLE = 0x2;
     }
 }

--- a/src/vbe_info.rs
+++ b/src/vbe_info.rs
@@ -1,32 +1,77 @@
 use core::fmt;
 
+/// This tag contains VBE metadata, VBE controller information returned by the
+/// VBE Function 00h and VBE mode information returned by the VBE Function 01h.
 #[derive(Debug, Copy, Clone)]
 #[repr(C, packed)]
 pub struct VBEInfoTag {
     typ: u32,
     length: u32,
+
+    /// Indicates current video mode in the format specified in VBE 3.0. 
     pub mode: u16,
+
+    /// Contain the segment of the table of a protected mode interface defined in VBE 2.0+.
     pub interface_segment: u16,
+
+    /// Contain the segment offset of the table of a protected mode interface defined in VBE 2.0+.
     pub interface_offset: u16,
+
+    /// Contain the segment length of the table of a protected mode interface defined in VBE 2.0+.
     pub interface_length: u16,
+
+    /// Contains VBE controller information returned by the VBE Function `00h`.
     pub control_info: VBEControlInfo,
+
+    /// Contains VBE mode information returned by the VBE Function `01h`.
     pub mode_info: VBEModeInfo
 }
 
+/// VBE controller information.
+///
+/// The capabilities of the display controller, the revision level of the
+/// VBE implementation, and vendor specific information to assist in supporting all display
+/// controllers in the field are listed here.
+///
+/// The purpose of this struct is to provide information to the kernel about the general
+/// capabilities of the installed VBE software and hardware.
 #[derive(Copy, Clone)]
 #[repr(C, packed)]
 pub struct VBEControlInfo {
+    /// VBE Signature aka "VESA".
     pub signature: [u8; 4],
+
+    /// The VBE version.
     pub version: u16,
+
+    /// A far pointer the the OEM String.
     pub oem_string_ptr: u32,
+
+    /// Capabilities of the graphics controller.
     pub capabilities: VBECapabilities,
+
+    /// Far pointer to the video mode list.
     pub mode_list_ptr: u32,
-    pub total_memory: u16, // Measured in 64kb blocks.
-    pub oem_software_revision: u16,  
+
+    /// Number of 64KiB memory blocks (Added for VBE 2.0+).
+    pub total_memory: u16,
+
+    /// VBE implementation software revision.
+    pub oem_software_revision: u16,
+
+    /// Far pointer to the vendor name string.
     pub oem_vendor_name_ptr: u32,
+
+    /// Far pointer to the product name string.
     pub oem_product_name_ptr: u32,
+
+    /// Far pointer to the product revision string.
     pub oem_product_revision_ptr: u32,
+
+    /// Reserved for VBE implementation scratch area.
     reserved: [u8; 222],
+
+    /// Data area for OEM strings.
     oem_data: [u8; 256]
 }
 
@@ -49,35 +94,91 @@ impl fmt::Debug for VBEControlInfo {
     }
 }
 
+
+/// Extended information about a specific VBE display mode from the
+/// mode list returned by `VBEControlInfo` (VBE Function `00h`).
 #[derive(Copy, Clone)]
 #[repr(C, packed)]
 pub struct VBEModeInfo {
+    /// Mode attributes.
     pub mode_attributes: VBEModeAttributes,
+
+    /// Window A attributes.
     pub window_a_attributes: VBEWindowAttributes,
+
+    /// Window B attributes.
     pub window_b_attributes: VBEWindowAttributes,
-    pub window_granularity: u16, // Measured in kilobytes.
+
+    /// Window granularity (Measured in Kilobytes.)
+    pub window_granularity: u16,
+
+    /// Window size.
     pub window_size: u16,
+
+    /// Window A start segment.
     pub window_a_segment: u16,
+
+    /// Window B start segment.
     pub window_b_segment: u16,
+
+    /// Real mode pointer to window function.
     pub window_function_ptr: u32,
+
+    /// Bytes per scan line
     pub pitch: u16,
+
+    /// Horizontal and vertical resolution in pixels or characters.
     pub resolution: (u16, u16),
+
+    /// Character cell width and height in pixels.
     pub character_size: (u8, u8),
+
+    /// Number of memory planes.
     pub number_of_planes: u8,
+
+    /// Bits per pixel
     pub bpp: u8,
+
+    /// Number of banks
     pub number_of_banks: u8,
+
+    /// Memory model type
     pub memory_model: VBEMemoryModel,
-    pub bank_size: u8, // Measured in kilobytes.
+
+    /// Bank size (Measured in Kilobytes.)
+    pub bank_size: u8,
+
+    /// Number of images.
     pub number_of_image_pages: u8,
+
+    /// Reserved for page function.
     reserved0: u8,
+
+    /// Red colour field.
     pub red_field: VBEField,
+
+    /// Green colour field.
     pub green_field: VBEField,
+
+    /// Blue colour field.
     pub blue_field: VBEField,
+
+    /// Reserved colour field.
     pub reserved_field: VBEField,
+
+    /// Direct colour mode attributes.
     pub direct_color_attributes: VBEDirectColorAttributes,
+
+    /// Physical address for flat memory frame buffer
     pub framebuffer_base_ptr: u32,
+
+    /// This should be a reserved field???
     pub offscreen_memory_offset: u32,
+
+    /// This should be a reserved field???
     pub offscreen_memory_size: u16,
+
+    /// Remainder of mode info block
     reserved1: [u8; 206]
 }
 
@@ -115,50 +216,103 @@ impl fmt::Debug for VBEModeInfo {
     }
 }
 
+/// A VBE colour field.
+///
+/// Descirbes the size and position of some colour capability.
 #[derive(Debug, PartialEq, Copy, Clone)]
 #[repr(C, packed)]
 pub struct VBEField {
+    /// The size, in bits, of the color components of a direct color pixel.
     pub size: u8,
+
+    /// define the bit position within the direct color pixel or YUV pixel of
+    /// the least significant bit of the respective color component.
     pub position: u8
 }
 
 bitflags! {
+    /// The Capabilities field indicates the support of specific features in the graphics environment.
     pub struct VBECapabilities: u32 {
+        /// Can the DAC be switched between 6 and 8 bit modes.
         const SWITCHABLE_DAC = 0x1;     // The DAC can be switched between 6 and 8-bit modes.
+
+        /// Is the controller VGA compatible.
         const NOT_VGA_COMPATIBLE = 0x2; // The controller can be switched into VGA modes.
+
+        /// The operating behaviour of the RAMDAC
         const RAMDAC_FIX = 0x4;         // When writing lots of information to the palette, the blank bit should be used.
     }
 }
 
 bitflags! {
+    /// A Mode attributes bitfield.
     pub struct VBEModeAttributes: u16 {
+        /// Mode supported by hardware configuration.
         const SUPPORTED = 0x1;           // This mode is supported by the hardware.
+
+        /// TTY Output functions supported by BIOS
         const TTY_SUPPORTED = 0x4;       // TTY output is supported.
+
+        /// Color support.
         const COLOR = 0x8;
+
+        /// Mode type (text or graphics).
         const GRAPHICS = 0x10;
+
+        /// VGA compatibility.
         const NOT_VGA_COMPATIBLE = 0x20;
-        const NO_VGA_WINDOW = 0x40;      // If this is set, the window A and B fields of VBEModeInfo are invalid.
-        const LINEAR_FRAMEBUFFER = 0x80; // A linear framebuffer is available for this mode.
+
+        /// VGA Window compatibility.
+        ///
+        /// If this is set, the window A and B fields of VBEModeInfo are invalid. 
+        const NO_VGA_WINDOW = 0x40;
+
+        /// Linear framebugger availability.
+        ///
+        /// Set if a linear framebuffer is available for this mode.
+        const LINEAR_FRAMEBUFFER = 0x80;
     }
 }
 
 bitflags! {
+    /// The WindowAttributes describe the characteristics of the CPU windowing
+    /// scheme such as whether the windows exist and are read/writeable, as follows:
     pub struct VBEWindowAttributes: u8 {
+        /// Relocatable window(s) supported?
         const RELOCATABLE = 0x1;
+
+        /// Window is readable?
         const READABLE = 0x2;
+
+        /// Window is writeable?
         const WRITEABLE = 0x4;
     }
 }
 
 bitflags! {
+
+    /// The DirectColorModeInfo field describes important characteristics of direct color modes.
+    ///
+    /// Bit D0 specifies whether the color ramp of the DAC is fixed or
+    /// programmable. If the color ramp is fixed, then it can not be changed.
+    /// If the color ramp is programmable, it is assumed that the red, green,
+    /// and blue lookup tables can be loaded by using VBE Function 09h
+    /// (it is assumed all color ramp data is 8 bits per primary).
+    /// Bit D1 specifies whether the bits in the Rsvd field of the direct color
+    /// pixel can be used by the application or are reserved, and thus unusable.
     pub struct VBEDirectColorAttributes: u8 {
-        const PROGRAMMABLE = 0x1;       // The color ramp of the DAC is programmable.
-        const RESERVED_USABLE = 0x2;    // The bits of the 'reserved' field are usable by the application.
+        /// Color ramp is fixed/programmable
+        const PROGRAMMABLE = 0x1;
+
+        /// Bits in Rsvd field are usable/reserved
+        const RESERVED_USABLE = 0x2;
     }
 }
 
+/// The MemoryModel field specifies the general type of memory organization used in modes.
 #[derive(Debug, PartialEq, Copy, Clone)]
 #[repr(u8)]
+#[allow(missing_docs)]
 pub enum VBEMemoryModel {
     Text = 0x00,
     CGAGraphics = 0x01,


### PR DESCRIPTION
I've started an attempt at solving #40 

Currently this PR introduces a crate level `deny(missing_docs)` and attempts at least a single line of documentation for every publicly visible item.

 It's not much but its better than nothing and over time I aim to add more sections covering examples and unsafe notices.