### PR TITLE
Add support for multiboot2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 An experimental Multiboot 2 crate for ELF-64 kernels. It's still incomplete, so please open an issue if you're missing some functionality. Contributions welcome!
 
-It uses the Multiboot 1.6 specification at http://nongnu.askapache.com/grub/phcoder/multiboot.pdf and the ELF 64 specification at http://www.uclibc.org/docs/elf-64-gen.pdf.
+It uses the Multiboot 2.0 specification at https://www.gnu.org/software/grub/manual/multiboot2/multiboot.html and the ELF 64 specification at http://www.uclibc.org/docs/elf-64-gen.pdf.
 
 Below is the draft for a blog post about this. I don't plan to finish it but maybe it's helpful as documentation.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1223,4 +1223,71 @@ mod tests {
         assert_eq!(ElfSectionType::StringTable, s1.section_type());
         assert!(s.next().is_none());
     }
+
+    #[test]
+    fn efi_memory_map() {
+        use memory_map::EFIMemoryAreaType;
+        #[repr(C, align(8))]
+        struct Bytes([u8; 72]);
+        // test that the EFI memory map is detected.
+        let bytes: Bytes = Bytes([
+            72, 0, 0, 0, // size
+            0, 0, 0, 0, // reserved
+            17, 0, 0, 0, // EFI memory map type
+            56, 0, 0, 0, // EFI memory map size
+            48, 0, 0, 0, // EFI descriptor size
+            1, 0, 0, 0, // EFI descriptor version, don't think this matters.
+            7, 0, 0, 0, // Type: EfiConventionalMemory
+            0, 0, 0, 0, // Padding
+            0, 0, 16, 0,// Physical Address: should be 0x100000
+            0, 0, 0, 0, // Extension of physical address.
+            0, 0, 16, 0,// Virtual Address: should be 0x100000
+            0, 0, 0, 0, // Extension of virtual address.
+            4, 0, 0, 0, // 4 KiB Pages: 16 KiB
+            0, 0, 0, 0, // Extension of pages
+            0, 0, 0, 0, // Attributes of this memory range.
+            0, 0, 0, 0, // Extension of attributes
+            0, 0, 0, 0, // end tag type.
+            8, 0, 0, 0, // end tag size.
+        ]);
+        let addr = bytes.0.as_ptr() as usize;
+        let boot_info = unsafe { load(addr) };
+        assert_eq!(addr, boot_info.start_address());
+        assert_eq!(addr + bytes.0.len(), boot_info.end_address());
+        assert_eq!(bytes.0.len(), boot_info.total_size() as usize);
+        let efi_memory_map = boot_info.efi_memory_map_tag().unwrap();
+        let mut efi_mmap_iter = efi_memory_map.memory_areas();
+        let desc = efi_mmap_iter.next().unwrap();
+        assert_eq!(desc.physical_address(), 0x100000);
+        assert_eq!(desc.size(), 16384);
+        assert_eq!(desc.typ(), EFIMemoryAreaType::EfiConventionalMemory);
+        // test that the EFI memory map is not detected if the boot services
+        // are not exited.
+        struct Bytes2([u8; 80]);
+        let bytes2: Bytes2 = Bytes2([
+            80, 0, 0, 0, // size
+            0, 0, 0, 0, // reserved
+            17, 0, 0, 0, // EFI memory map type
+            56, 0, 0, 0, // EFI memory map size
+            48, 0, 0, 0, // EFI descriptor size
+            1, 0, 0, 0, // EFI descriptor version, don't think this matters.
+            7, 0, 0, 0, // Type: EfiConventionalMemory
+            0, 0, 0, 0, // Padding
+            0, 0, 16, 0,// Physical Address: should be 0x100000
+            0, 0, 0, 0, // Extension of physical address.
+            0, 0, 16, 0,// Virtual Address: should be 0x100000
+            0, 0, 0, 0, // Extension of virtual address.
+            4, 0, 0, 0, // 4 KiB Pages: 16 KiB
+            0, 0, 0, 0, // Extension of pages
+            0, 0, 0, 0, // Attributes of this memory range.
+            0, 0, 0, 0, // Extension of attributes
+            18, 0, 0, 0, // Tag ExitBootServices not terminated.
+            8, 0, 0, 0, // Tag ExitBootServices size.
+            0, 0, 0, 0, // end tag type.
+            8, 0, 0, 0, // end tag size.
+        ]);
+        let boot_info = unsafe { load(bytes2.0.as_ptr() as usize) };
+        let efi_mmap = boot_info.efi_memory_map_tag();
+        assert!(efi_mmap.is_none());
+    }
 }

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -221,8 +221,8 @@ impl EFIMemoryDesc {
     }
 
     /// The size in bytes of the memory region.
-    pub fn size(&self, page_size: u64) -> usize {
-        (self.num_pages * page_size) as usize
+    pub fn size(&self, page_size: u64) -> u64 {
+        self.num_pages * page_size
     }
 
     /// The type of the memory region.
@@ -256,35 +256,8 @@ pub struct EFIBootServicesNotExited {
     size: u32,
 }
 
-/// Contains pointer to boot loader image handle.
-#[derive(Debug)]
-#[repr(C)]
-pub struct EFIImageHandle32 {
-    typ: u32,
-    size: u32,
-    pointer: u32,
-}
 
-/// Contains pointer to boot loader image handle.
-#[derive(Debug)]
-#[repr(C)]
-pub struct EFIImageHandle64 {
-    typ: u32,
-    size: u32,
-    pointer: u64,
-}
-
-/// If the image has relocatable header tag, this tag contains the image's 
-/// base physical address.
-#[derive(Debug)]
-#[repr(C)]
-pub struct ImageLoadPhysAddr {
-    typ: u32,
-    size: u32,
-    load_base_addr: u32,
-}
-
-/// An iterator over All EFI memory areas.
+/// An iterator over ALL EFI memory areas.
 #[derive(Clone, Debug)]
 pub struct EFIMemoryAreaIter<'a> {
     current_area: u64,
@@ -301,9 +274,7 @@ impl<'a> Iterator for EFIMemoryAreaIter<'a> {
         } else {
             let area = unsafe{&*(self.current_area as *const EFIMemoryDesc)};
             self.current_area = self.current_area + (self.entry_size as u64);
-            if area.typ() == EFIMemoryAreaType::EfiConventionalMemory {
-                Some(area)
-            } else {self.next()}
+            Some(area)
         }
     }
 }

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -221,8 +221,9 @@ impl EFIMemoryDesc {
     }
 
     /// The size in bytes of the memory region.
-    pub fn size(&self, page_size: u64) -> u64 {
-        self.num_pages * page_size
+    pub fn size(&self) -> u64 {
+        // Spec says this is number of 4KiB pages.
+        self.num_pages * 4096
     }
 
     /// The type of the memory region.

--- a/src/rsdp.rs
+++ b/src/rsdp.rs
@@ -43,6 +43,34 @@ impl EFISdt64 {
     }
 }
 
+/// Contains pointer to boot loader image handle.
+#[derive(Debug)]
+#[repr(C)]
+pub struct EFIImageHandle32 {
+    typ: u32,
+    size: u32,
+    pointer: u32,
+}
+
+/// Contains pointer to boot loader image handle.
+#[derive(Debug)]
+#[repr(C)]
+pub struct EFIImageHandle64 {
+    typ: u32,
+    size: u32,
+    pointer: u64,
+}
+
+/// If the image has relocatable header tag, this tag contains the image's 
+/// base physical address.
+#[derive(Debug)]
+#[repr(C)]
+pub struct ImageLoadPhysAddr {
+    typ: u32,
+    size: u32,
+    load_base_addr: u32,
+}
+
 /// This tag contains a copy of RSDP as defined per ACPI 1.0 specification. 
 #[derive(Clone, Copy, Debug)]
 #[repr(C, packed)]

--- a/src/rsdp.rs
+++ b/src/rsdp.rs
@@ -11,6 +11,38 @@ use core::str;
 
 const RSDPV1_LENGTH: usize = 20;
 
+/// EFI system table in 32 bit mode
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed)]
+pub struct EFISdt32 {
+    typ: u32,
+    size: u32,
+    pointer: u32,
+}
+
+impl EFISdt32 {
+    /// The Physical address of a i386 EFI system table.
+    pub fn sdt_address(&self) -> usize {
+        self.pointer as usize
+    }
+}
+
+/// EFI system table in 64 bit mode
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed)]
+pub struct EFISdt64 {
+    typ: u32,
+    size: u32,
+    pointer: u64,
+}
+
+impl EFISdt64 {
+    /// The Physical address of a x86_64 EFI system table.
+    pub fn sdt_address(&self) -> usize {
+        self.pointer as usize
+    }
+}
+
 /// This tag contains a copy of RSDP as defined per ACPI 1.0 specification. 
 #[derive(Clone, Copy, Debug)]
 #[repr(C, packed)]


### PR DESCRIPTION
Fix #30 
[Multiboot 2.0](https://www.gnu.org/software/grub/manual/multiboot2/multiboot.html)

TODO:

- [x] Testing
- [x] More EFI tables: SDT, image handle.
