### PR TITLE
Add docs and crates.io badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # multiboot2-elf64
 [![Build Status](https://travis-ci.org/rust-osdev/multiboot2-elf64.svg?branch=master)](https://travis-ci.org/rust-osdev/multiboot2-elf64)
+[![crates.io](https://img.shields.io/crates/v/multiboot2.svg)](https://crates.io/crates/multiboot2)
+[![docs](https://docs.rs/multiboot2/badge.svg?branch=master)](https://docs.rs/multiboot2/)
 
 An experimental Multiboot 2 crate for ELF-64 kernels. It's still incomplete, so please open an issue if you're missing some functionality. Contributions welcome!
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # multiboot2-elf64
 [![Build Status](https://travis-ci.org/rust-osdev/multiboot2-elf64.svg?branch=master)](https://travis-ci.org/rust-osdev/multiboot2-elf64)
 [![crates.io](https://img.shields.io/crates/v/multiboot2.svg)](https://crates.io/crates/multiboot2)
-[![docs](https://docs.rs/multiboot2/badge.svg?branch=master)](https://docs.rs/multiboot2/)
+[![docs](https://docs.rs/multiboot2/badge.svg)](https://docs.rs/multiboot2/)
 
 An experimental Multiboot 2 crate for ELF-64 kernels. It's still incomplete, so please open an issue if you're missing some functionality. Contributions welcome!
 


### PR DESCRIPTION
Closes #40 

Noticed that the docs badge takes a few seconds to load. Not sure if it's a problem with the svg link I chose or it's an issue with the docs.rs website.