### PR TITLE
Improve usage of repr(packed)

### DIFF
--- a/src/elf_sections.rs
+++ b/src/elf_sections.rs
@@ -13,7 +13,7 @@ pub unsafe fn elf_sections_tag(tag: &Tag, offset: usize) -> ElfSectionsTag {
     assert_eq!(9, tag.typ);
     let es = ElfSectionsTag {
         inner: (tag as *const Tag).offset(1) as *const ElfSectionsTagInner,
-        offset: offset,
+        offset,
     };
     assert!((es.get().entry_size * es.get().shndx) <= tag.size);
     es

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -66,7 +66,7 @@ pub struct FramebufferField {
 
 /// A framebuffer color descriptor in the palette.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(C, packed)]
+#[repr(C, packed)] // only repr(C) would add unwanted padding at the end
 pub struct FramebufferColor {
     /// The Red component of the color.
     pub red: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub struct BootInformation {
 }
 
 #[derive(Clone, Copy)]
-#[repr(C, packed)]
+#[repr(C)]
 struct BootInformationInner {
     total_size: u32,
     _reserved: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub struct BootInformation {
     offset: usize,
 }
 
+#[derive(Clone, Copy)]
 #[repr(C, packed)]
 struct BootInformationInner {
     total_size: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,6 +467,15 @@ mod tests {
     }
 
     #[test]
+    /// Compile time test for `BootLoaderNameTag`.
+    fn name_tag_size() {
+        use BootLoaderNameTag;
+        unsafe {
+            core::mem::transmute::<[u8; 9], BootLoaderNameTag>([0u8; 9]);
+        }
+    }
+
+    #[test]
     fn framebuffer_tag_rgb() {
         // direct RGB mode test:
         // taken from GRUB2 running in QEMU at
@@ -584,6 +593,16 @@ mod tests {
                 ]
             ),
             _ => panic!("Expected indexed framebuffer type."),
+        }
+    }
+
+    #[test]
+    /// Compile time test for `FramebufferTag`.
+    fn framebuffer_tag_size() {
+        use crate::FramebufferTag;
+        unsafe {
+            // 24 for the start + 24 for `FramebufferType`.
+            core::mem::transmute::<[u8; 48], FramebufferTag>([0u8; 48]);
         }
     }
 
@@ -742,6 +761,16 @@ mod tests {
             assert_eq!(vbe.mode_info.framebuffer_base_ptr, 4244635648);
             assert_eq!(vbe.mode_info.offscreen_memory_offset, 0);
             assert_eq!(vbe.mode_info.offscreen_memory_size, 0);
+        }
+    }
+
+    #[test]
+    /// Compile time test for `VBEInfoTag`.
+    fn vbe_info_tag_size() {
+        use VBEInfoTag;
+        unsafe {
+            // 16 for the start + 512 from `VBEControlInfo` + 256 from `VBEModeInfo`.
+            core::mem::transmute::<[u8; 784], VBEInfoTag>([0u8; 784]);
         }
     }
 
@@ -1226,6 +1255,16 @@ mod tests {
     }
 
     #[test]
+    /// Compile time test for `ElfSectionsTag`.
+    fn elf_sections_tag_size() {
+        use super::ElfSectionsTag;
+        unsafe {
+            // `ElfSectionsTagInner` is 12 bytes + 4 in the offset.
+            core::mem::transmute::<[u8; 16], ElfSectionsTag>([0u8; 16]);
+        }
+    }
+
+    #[test]
     fn efi_memory_map() {
         use memory_map::EFIMemoryAreaType;
         #[repr(C, align(8))]
@@ -1291,4 +1330,15 @@ mod tests {
         let efi_mmap = boot_info.efi_memory_map_tag();
         assert!(efi_mmap.is_none());
     }
+
+    #[test]
+    /// Compile time test for `EFIMemoryMapTag`.
+    fn efi_memory_map_tag_size() {
+        use super::EFIMemoryMapTag;
+        unsafe {
+            // `EFIMemoryMapTag` is 16 bytes + `EFIMemoryDesc` is 40 bytes.
+            core::mem::transmute::<[u8; 56], EFIMemoryMapTag>([0u8; 56]);
+        }
+    }
+
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -3,7 +3,7 @@ use header::{Tag, TagIter};
 /// This tag indicates to the kernel what boot module was loaded along with
 /// the kernel image, and where it can be found. 
 #[derive(Clone, Copy, Debug)]
-#[repr(C, packed)]
+#[repr(C, packed)] // only repr(C) would add unwanted padding near name_byte.
 pub struct ModuleTag {
     typ: u32,
     size: u32,

--- a/src/rsdp.rs
+++ b/src/rsdp.rs
@@ -13,7 +13,7 @@ const RSDPV1_LENGTH: usize = 20;
 
 /// EFI system table in 32 bit mode
 #[derive(Clone, Copy, Debug)]
-#[repr(C, packed)]
+#[repr(C, packed)] // only repr(C) would add unwanted padding before first_section
 pub struct EFISdt32 {
     typ: u32,
     size: u32,
@@ -29,7 +29,7 @@ impl EFISdt32 {
 
 /// EFI system table in 64 bit mode
 #[derive(Clone, Copy, Debug)]
-#[repr(C, packed)]
+#[repr(C)] 
 pub struct EFISdt64 {
     typ: u32,
     size: u32,


### PR DESCRIPTION
Close #38.
We occasionally use`repr(packed)` when the struct is unaligned. When we use it, I added a comment explaining why. In addition, we derive `Copy` and `Clone` to allow the compiler to copy the fields to locals.