### PR TITLE
chore: use `impl Iterator`

### DIFF
--- a/src/elf_sections.rs
+++ b/src/elf_sections.rs
@@ -41,7 +41,7 @@ impl ElfSectionsTag {
     ///     }
     /// }
     /// ```
-    pub fn sections(&self) -> ElfSectionIter {
+    pub fn sections(&self) -> impl Iterator<Item = ElfSection> {
         let string_section_offset = (self.get().shndx * self.get().entry_size) as isize;
         let string_section_ptr =
             unsafe { self.first_section().offset(string_section_offset) as *const _ };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,13 +31,12 @@ pub use elf_sections::{
 pub use framebuffer::{FramebufferColor, FramebufferField, FramebufferTag, FramebufferType};
 use header::{Tag, TagIter};
 pub use memory_map::{
-    EFIMemoryAreaType, EFIMemoryMapTag, EFIMemoryDesc, MemoryArea, MemoryAreaIter,
-    MemoryAreaType, MemoryMapTag,
+    EFIMemoryAreaType, EFIMemoryDesc, EFIMemoryMapTag, MemoryArea, MemoryAreaIter, MemoryAreaType,
+    MemoryMapTag,
 };
 pub use module::{ModuleIter, ModuleTag};
 pub use rsdp::{
-    EFIImageHandle32, EFIImageHandle64, EFISdt32, EFISdt64, ImageLoadPhysAddr, 
-    RsdpV1Tag, RsdpV2Tag,
+    EFIImageHandle32, EFIImageHandle64, EFISdt32, EFISdt64, ImageLoadPhysAddr, RsdpV1Tag, RsdpV2Tag,
 };
 pub use vbe_info::{
     VBECapabilities, VBEControlInfo, VBEDirectColorAttributes, VBEField, VBEInfoTag,
@@ -156,7 +155,7 @@ impl BootInformation {
     }
 
     /// Get an iterator of all module tags.
-    pub fn module_tags(&self) -> ModuleIter {
+    pub fn module_tags(&self) -> impl Iterator<Item = &ModuleTag> {
         module::module_iter(self.tags())
     }
 
@@ -207,10 +206,9 @@ impl BootInformation {
         // the memory map, as it could still be in use.
         match self.get_tag(18) {
             Some(_tag) => None,
-            None => {
-                self.get_tag(17)
-                    .map(|tag| unsafe { &*(tag as *const Tag as *const EFIMemoryMapTag) })
-            },
+            None => self
+                .get_tag(17)
+                .map(|tag| unsafe { &*(tag as *const Tag as *const EFIMemoryMapTag) }),
         }
     }
 
@@ -1279,9 +1277,9 @@ mod tests {
             1, 0, 0, 0, // EFI descriptor version, don't think this matters.
             7, 0, 0, 0, // Type: EfiConventionalMemory
             0, 0, 0, 0, // Padding
-            0, 0, 16, 0,// Physical Address: should be 0x100000
+            0, 0, 16, 0, // Physical Address: should be 0x100000
             0, 0, 0, 0, // Extension of physical address.
-            0, 0, 16, 0,// Virtual Address: should be 0x100000
+            0, 0, 16, 0, // Virtual Address: should be 0x100000
             0, 0, 0, 0, // Extension of virtual address.
             4, 0, 0, 0, // 4 KiB Pages: 16 KiB
             0, 0, 0, 0, // Extension of pages
@@ -1313,9 +1311,9 @@ mod tests {
             1, 0, 0, 0, // EFI descriptor version, don't think this matters.
             7, 0, 0, 0, // Type: EfiConventionalMemory
             0, 0, 0, 0, // Padding
-            0, 0, 16, 0,// Physical Address: should be 0x100000
+            0, 0, 16, 0, // Physical Address: should be 0x100000
             0, 0, 0, 0, // Extension of physical address.
-            0, 0, 16, 0,// Virtual Address: should be 0x100000
+            0, 0, 16, 0, // Virtual Address: should be 0x100000
             0, 0, 0, 0, // Extension of virtual address.
             4, 0, 0, 0, // 4 KiB Pages: 16 KiB
             0, 0, 0, 0, // Extension of pages
@@ -1340,5 +1338,4 @@ mod tests {
             core::mem::transmute::<[u8; 56], EFIMemoryMapTag>([0u8; 56]);
         }
     }
-
 }

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -27,7 +27,7 @@ impl MemoryMapTag {
     }
 
     /// Return an iterator over all marked memory areas.
-    pub fn all_memory_areas(&self) -> MemoryAreaIter {
+    pub fn all_memory_areas(&self) -> impl Iterator<Item = &MemoryArea> {
         let self_ptr = self as *const MemoryMapTag;
         let start_area = (&self.first_area) as *const MemoryArea;
         MemoryAreaIter {
@@ -111,7 +111,7 @@ impl<'a> Iterator for MemoryAreaIter<'a> {
         if self.current_area > self.last_area {
             None
         } else {
-            let area = unsafe{&*(self.current_area as *const MemoryArea)};
+            let area = unsafe { &*(self.current_area as *const MemoryArea) };
             self.current_area = self.current_area + (self.entry_size as u64);
             Some(area)
         }
@@ -260,7 +260,6 @@ pub struct EFIBootServicesNotExited {
     size: u32,
 }
 
-
 /// An iterator over ALL EFI memory areas.
 #[derive(Clone, Debug)]
 pub struct EFIMemoryAreaIter<'a> {
@@ -276,10 +275,9 @@ impl<'a> Iterator for EFIMemoryAreaIter<'a> {
         if self.current_area > self.last_area {
             None
         } else {
-            let area = unsafe{&*(self.current_area as *const EFIMemoryDesc)};
+            let area = unsafe { &*(self.current_area as *const EFIMemoryDesc) };
             self.current_area = self.current_area + (self.entry_size as u64);
             Some(area)
         }
     }
 }
-


### PR DESCRIPTION
Two return types are mixed so all return types are integrated to `impl
Iterator`.