### PR TITLE
fix(docs): remove a code example in the top page of the doc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multiboot2"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Philipp Oppermann <dev@phil-opp.com>", "Calvin Lee <cyrus296@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "An experimental Multiboot 2 crate for ELF-64/32 kernels."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,21 +7,6 @@
 //! The GNU Multiboot specification aims provide to a standardised
 //! method of sharing commonly used information about the host machine at
 //! boot time.
-//!
-//! # Examples
-//!
-//! ```ignore
-//! #![feature(asm)]
-//! 
-//! use multiboot2::load;
-//!
-//! // The Multiboot 2 specification dictates that the machine state after the
-//! // bootloader finishes its job will be that the boot information struct pointer
-//! // is stored in the `EBX` register.
-//! let multiboot_info_ptr: u32;
-//! unsafe { asm!("mov {}, ebx", out(reg) multiboot_info_ptr) };
-//! let boot_info = unsafe { load(multiboot_info_ptr as usize) };
-//! ```
 
 use core::fmt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,16 @@
 //! # Examples
 //!
 //! ```ignore
+//! #![feature(asm)]
+//! 
 //! use multiboot2::load;
 //!
 //! // The Multiboot 2 specification dictates that the machine state after the
 //! // bootloader finishes its job will be that the boot information struct pointer
 //! // is stored in the `EBX` register.
 //! let multiboot_info_ptr: u32;
-//! unsafe { asm!("mov $2, %ebx" : "=r"(multiboot_info_ptr)) };
-//! let boot_info = unsafe { load(multiboot_info_ptr) };
+//! unsafe { asm!("mov {}, ebx", out(reg) multiboot_info_ptr) };
+//! let boot_info = unsafe { load(multiboot_info_ptr as usize) };
 //! ```
 
 use core::fmt;


### PR DESCRIPTION
The previous version of the `asm!` macro is renamed to `llvm_asm!`. It will not be stable.