### PR TITLE
add multiboot2 magic number

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -2,6 +2,15 @@ use core::marker::PhantomData;
 use core::fmt::{Debug, Formatter};
 use core::cmp::Ordering;
 
+/// Magic number that a multiboot2-compliant boot loader will store in `eax` register
+/// right before handoff to the payload (the kernel). This value can be used to check,
+/// that the kernel was indeed booted via multiboot2.
+///
+/// Caution: You might need some assembly code (e.g. GAS or NASM) first, which
+/// moves `eax` to another register, like `edi`. Otherwise it probably happens,
+/// that the Rust compiler output changes `eax` before you can access it.
+pub const MB2_MAGIC: u32 = 0x36d76289;
+
 /// Possible Types of a [`Tag`]. The names and values are taken from the example C code
 /// at the bottom of the Multiboot2 specification.
 #[repr(u32)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub use elf_sections::{
 };
 pub use framebuffer::{FramebufferColor, FramebufferField, FramebufferTag, FramebufferType};
 use header::{Tag, TagIter, TagType};
+pub use header::MB2_MAGIC;
 pub use memory_map::{
     EFIMemoryAreaType, EFIMemoryDesc, EFIMemoryMapTag, MemoryArea, MemoryAreaIter, MemoryAreaType,
     MemoryMapTag,


### PR DESCRIPTION
To my surprise the multiboot2 magic number is not yet available inside the crate. In my Rust kernel I currently have a hard-coded constant. I think it would be beneficial, if we upstream this into the crate.