### PR TITLE
renamed multiboot2 bootloader magic constant

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 /// Caution: You might need some assembly code (e.g. GAS or NASM) first, which
 /// moves `eax` to another register, like `edi`. Otherwise it probably happens,
 /// that the Rust compiler output changes `eax` before you can access it.
-pub const MB2_MAGIC: u32 = 0x36d76289;
+pub const MULTIBOOT2_BOOTLOADER_MAGIC: u32 = 0x36d76289;
 
 /// Possible Types of a [`Tag`]. The names and values are taken from the example C code
 /// at the bottom of the Multiboot2 specification.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use elf_sections::{
     ElfSection, ElfSectionFlags, ElfSectionIter, ElfSectionType, ElfSectionsTag,
 };
 pub use framebuffer::{FramebufferColor, FramebufferField, FramebufferTag, FramebufferType};
-pub use header::MB2_MAGIC;
+pub use header::MULTIBOOT2_BOOTLOADER_MAGIC;
 use header::{Tag, TagIter, TagType};
 pub use memory_map::{
     EFIMemoryAreaType, EFIMemoryDesc, EFIMemoryMapTag, MemoryArea, MemoryAreaIter, MemoryAreaType,


### PR DESCRIPTION
In the multiboot2 spec the constant is named `MULTIBOOT2_BOOTLOADER_MAGIC`. I think we should rename it (the current one is not released yet, therefore not breaking). Eventually we have the two constants `MULTIBOOT2_BOOTLOADER_MAGIC` and `MULTIBOOT2_HEADER_MAGIC` (#79)